### PR TITLE
README.md: Fix markdown immediately following raw HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You are welcome to contribute with more items provided below.
          alt="Dependency Status">
   </a>
 </p>
+
 If you're using [ESLint](http://eslint.org/), you can install a
 [plugin](http://eslint.org/docs/user-guide/configuring#using-the-configuration-from-a-plugin) that
 will help you identify places in your codebase where you don't (may not) need Lodash/Underscore.


### PR DESCRIPTION
Without a blank line after raw HTML, the subsequent markdown doesn't get rendered as intended.