### PR TITLE
fix example for  _.template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ Create a template function.
 
   // Native
   const templateLitreal = (value) => `hello ${value.user}`;
-  templateLiterlFunction({ 'user': 'fred' });
+  templateLitreal({ 'user': 'fred' });
   ```
 
 #### Browser Support


### PR DESCRIPTION
Fixed the error of the function name.This error causes the function to not execute correctly.