### PR TITLE
Fix flatten implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Flattens array a single level deep.
   // => [1, 2, [3, [4]], 5]
 
   // Native
-  const flatten = [1, [2, [3, [4]], 5]].reduce( (a, b) => [...a, ...b], [])
+  const flatten = [1, [2, [3, [4]], 5]].reduce( (a, b) => a.concat(b), [])
   // => [1, 2, [3, [4]], 5]
 
   ```


### PR DESCRIPTION
While using this repo as a guideline for replacing some stuff, I noticed that the `flatten` implementation is wrong. If I try to execute I receive this error:

![image](https://user-images.githubusercontent.com/5040487/33341860-56e0a49a-d467-11e7-9f92-20e472394067.png)

I think that this fixes it.

Fix #100 