### PR TITLE
update(flattenDeep): remove an redundant call of flattenDeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Recursively flattens array.
 
   // Native
   const flattenDeep = (arr) => Array.isArray(arr)
-    ? arr.reduce( (a, b) => [...flattenDeep(a), ...flattenDeep(b)] , [])
+    ? arr.reduce( (a, b) => a.concat(flattenDeep(b)) , [])
     : [arr]
 
   flattenDeep([1, [[2], [3, [4]], 5]])


### PR DESCRIPTION
Hi all,

The first is unneccessary because the iteration result `a` is already flatten.

Thanks.