### PR TITLE
Add missing examples and fix incorrect output in _.range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,12 +1135,15 @@ Creates an array of numbers progressing from start up to.
 
   // Native ( solution with Array.from )
   Array.from({length: 4}, (_, i) => i)  // output: [0, 1, 2, 3]
-  Array.from({length: 4}, (_, i) => -i) // output: [0, -1, -2, -3]
+  Array.from({length: 4}, (_, i) => -i) // output: [-0, -1, -2, -3]
   Array.from({length: 4}, (_, i) => i + 1) // output: [1, 2, 3, 4]
   Array.from({length: 4}, (_, i) => i * 5) // output: [0, 5, 10, 15]
 
   // Native ( solution with keys() and spread )
-  [...Array(4).keys()] // output: [0, 1, 2, 3]
+  [...Array(4).keys()]  // output: [0, 1, 2, 3]
+  [...Array(4).keys()].map(k => -k) // output: [-0, -1, -2, -3]
+  [...Array(4).keys()].map(k => k + 1)  // output: [1, 2, 3, 4]
+  [...Array(4).keys()].map(k => k * 5)  // output: [0, 5, 10, 15]
   ```
 
 


### PR DESCRIPTION
Three missing examples have been added for _.range replacement using `keys()` solution.

Also ES implements signed zeros thus in this case `0` multiplied by `-1` is equal to `-0` but usually that didn't matter since `+0 === -0` is equal to `true`.

If it's a meaningful problem you can always use `parseInt()` in map which converts `-0` to `+0` and leave rest of integers untouched.