### PR TITLE
fix(uniq): update example to cover Internet Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ Lodash and Underscore are great modern JavaScript utility libraries, and they ar
 
 You are welcome to contribute with more items provided below.
 
-* If you are targeting legacy JavaScript engine with those ES5 methods, you can use [es5-shim](https://github.com/es-shims/es5-shim)
+**If you are targeting legacy JavaScript engine with those ES5 methods, you can use [es5-shim](https://github.com/es-shims/es5-shim)
 
-* Please note that, the examples used below are just showing you the native alternative of performing certain tasks. For some of the functions, Lodash provides you more options than native built-ins. This list is not a 1:1 comparison.
-
-* Please send a PR if you want to add or modify the code. No need to open an issue unless it's something big and you want to discuss.
+**Please note that, the examples used below are just showing you the native alternative of performing certain tasks. For some of the functions, Lodash provides you more options than native built-ins. This list is not a 1:1 comparison.
 
 
 ## Voice of Developers
@@ -1292,7 +1290,7 @@ Produces a duplicate-free version of the array, using === to test object equalit
 
   // Native
   var array = [1, 2, 1, 4, 1, 3];
-  var result = [...new Set(array)];
+  var result = array.filter((v, i, a) => a.indexOf(v) === i);
   console.log(result)
   // output: [1, 2, 4, 3]
   ```

--- a/README.md
+++ b/README.md
@@ -1289,10 +1289,10 @@ Produces a duplicate-free version of the array, using === to test object equalit
   // output: [1, 2, 4, 3]
 
   // Native
-  var array = [1, 2, 1, 4, 1, 3];
+  var array = [1, 1, 2, 3, 4, 4, 4];
   var result = array.filter((v, i, a) => a.indexOf(v) === i);
   console.log(result)
-  // output: [1, 2, 4, 3]
+  // output: [1, 2, 3, 4]
   ```
 
 #### Browser Support

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Lodash and Underscore are great modern JavaScript utility libraries, and they ar
 
 You are welcome to contribute with more items provided below.
 
-**If you are targeting legacy JavaScript engine with those ES5 methods, you can use [es5-shim](https://github.com/es-shims/es5-shim)
+* If you are targeting legacy JavaScript engine with those ES5 methods, you can use [es5-shim](https://github.com/es-shims/es5-shim)
 
-**Please note that, the examples used below are just showing you the native alternative of performing certain tasks. For some of the functions, Lodash provides you more options than native built-ins. This list is not a 1:1 comparison.
+* Please note that, the examples used below are just showing you the native alternative of performing certain tasks. For some of the functions, Lodash provides you more options than native built-ins. This list is not a 1:1 comparison.
+
+* Please send a PR if you want to add or modify the code. No need to open an issue unless it's something big and you want to discuss.
 
 
 ## Voice of Developers
@@ -82,6 +84,8 @@ For more information, see [Configuring the ESLint Plugin](configuring.md)
 1. [_.chunk](#_chunk)
 1. [_.compact](#_compact)
 1. [_.concat](#_concat)
+1. [_.difference](#_difference)
+1. [_.drop](#_drop)
 1. [_.fill](#_fill)
 1. [_.find](#_find)
 1. [_.findIndex](#_findindex)
@@ -91,16 +95,15 @@ For more information, see [Configuring the ESLint Plugin](configuring.md)
 1. [_.fromPairs](#_frompairs)
 1. [_.head and _.tail](#_head-and-_tail)
 1. [_.indexOf](#_indexof)
+1. [_.intersection](#_intersection)
+1. [_.isArray](#_isarray)
+1. [_.isArrayBuffer](#_isarraybuffer)
 1. [_.join](#_join)
 1. [_.last](#_last)
 1. [_.lastIndexOf](#_lastindexof)
 1. [_.reverse](#_reverse)
-1. [_.without](#_without)
-1. [_.intersection](#_intersection)
-1. [_.difference](#_difference)
 1. [_.slice](#_slice)
-1. [_.isArray](#_isarray)
-1. [_.isArrayBuffer](#_isarraybuffer)
+1. [_.without](#_without)
 
 **[Collection*](#collection*)**
 
@@ -113,6 +116,7 @@ then Lodash/Underscore is the better option.*
 1. [_.filter](#_filter)
 1. [_.groupBy](#_groupby)
 1. [_.includes](#_includes)
+1. [_.keyBy](#_keyBy)
 1. [_.map](#_map)
 1. [_.minBy and _.maxBy](#_minby-and-_maxby)
 1. [_.orderBy](#_sortby-and-_orderby)
@@ -133,36 +137,49 @@ then Lodash/Underscore is the better option.*
 
 **[Lang](#lang)**
 
+1. [_.gt](#_gt)
+1. [_.gte](#_gte)
+1. [_.isEmpty](#_isempty)
+1. [_.isFinite](#_isfinite)
+1. [_.isInteger](#_isInteger)
 1. [_.isNaN](#_isnan)
 1. [_.isNil](#_isnil)
 1. [_.isNull](#_isnull)
 1. [_.isUndefined](#_isundefined)
-1. [_.gt](#_gt)
-1. [_.gte](#_gte)
 
 **[Object](#object)**
 
 1. [_.assign](#_assign)
-1. [_.keys](#_keys)
-1. [_.toPairs](#_topairs)
-1. [_.values](#_values)
+1. [_.extend](#_extend)
 1. [_.get](#_get)
+1. [_.keys](#_keys)
 1. [_.omit](#_omit)
 1. [_.pick](#_pick)
 1. [_.pickBy](#_pickby)
+1. [_.toPairs](#_topairs)
+1. [_.values](#_values)
 
 **[String](#string)**
 
+1. [_.padStart and _.padEnd](#_padstart-and-_padend)
 1. [_.repeat](#_repeat)
+1. [_.replace](#_replace)
+1. [_.split](#_split)
+1. [_.startsWith](#startsWith)
 1. [_.template](#_template)
 1. [_.toLower](#_tolower)
 1. [_.toUpper](#_toupper)
 1. [_.trim](#_trim)
-1. [_.replace](#_replace)
+1. [_.upperFirst](#_upperFirst)
 
 **[Util](#string)**
 
 1. [_.times](#_times)
+
+**[Number](#number)**
+
+1. [_.inRange](#_inRange)
+2. [_.random](#_random)
 
 ## Array
 
@@ -196,11 +213,11 @@ chunk(['a', 'b', 'c', 'd'], 3);
 
 ```
 
-#### Browser Support
+#### Browser Support for Spread in array literals
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-   ✔  |  ✔ |  Not Supported |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+   46.0 ✔  | 12.0 ✔ | 16.0 ✔ |  ✖ |  37.0 ✔ |  8.0 ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -216,11 +233,11 @@ Creates an array with all falsy values removed.
   [0, 1, false, 2, '', 3].filter(Boolean)
   ```
 
-#### Browser Support
+#### Browser Support for `array.prototype.filter`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-   ✔  |  1.5 ✔ |  9 ✔ |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+   ✔  |  ✔ |  1.5 ✔ |  9.0 ✔ |  ✔ |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -244,11 +261,70 @@ Creates a new array concatenating array with any additional arrays and/or values
   // output: [1, 2, 3, [4]]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.concat()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-1.0  ✔  | 1.0 ✔ |  5.5 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+1.0  ✔  | ✔  |  1.0 ✔ |  5.5 ✔  |  ✔  |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.difference
+Similar to [without](#_without), but returns the values from array that are not present in the other arrays.
+
+  ```js
+  // Underscore/Lodash
+  console.log(_.difference([1, 2, 3, 4, 5], [5, 2, 10]))
+  // output: [1, 3, 4]
+
+  // Native
+  var arrays = [[1, 2, 3, 4, 5], [5, 2, 10]];
+  console.log(arrays.reduce(function(a, b) {
+    return a.filter(function(value) {
+      return !b.includes(value);
+    });
+  }));
+  // output: [1, 3, 4]
+
+  // ES6
+  let arrays = [[1, 2, 3, 4, 5], [5, 2, 10]];
+  console.log(arrays.reduce((a, b) => a.filter(c => !b.includes(c))));
+  // output: [1, 3, 4]
+  ```
+
+#### Browser Support for `Array.prototype.reduce()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+   ✔  |  ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.drop
+
+Creates a slice of array with n elements dropped from the beginning.
+
+  ```js
+  // Underscore/Lodash
+  _.drop([1, 2, 3]);
+  // => [2, 3]
+
+  _.drop([1, 2, 3], 2);
+  // => [3]
+
+  // Native
+  [1, 2, 3].slice(1);
+  // => [2, 3]
+  
+  [1, 2, 3].slice(2);
+  // => [3]
+  ```
+
+#### Browser Support for `Array.prototype.slice()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  |  ✔  |  1.0 ✔  |  ✔  |  ✔  | ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -287,11 +363,11 @@ Fills elements of array with value from start up to, but not including, end.
   // output: [4, '*', '*', 10]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.fill()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  45.0 ✔ | 31.0 ✔ |  Not supported  |  32.0 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  45.0 ✔ | ✔  | 31.0 ✔ |  ✖  |  32.0 ✔ |  8 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -321,11 +397,11 @@ Returns the value of the first element in the array that satisfies the provided 
   // output: object for 'barney'
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.find()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  45.0 ✔ | 25.0 ✔ |  Not supported  |  32.0 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  45.0 ✔ | ✔ | 25.0 ✔ |  ✖  |  32.0 ✔ |  7.1 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -357,11 +433,11 @@ Returns the index of the first element in the array that satisfies the provided 
   // output: 1
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.findIndex()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  45.0 ✔ | 25.0 ✔ |  Not supported  |  32.0 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  45.0 ✔ | ✔ | 25.0 ✔ |  ✖  |  32.0 ✔ |  7.1 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -395,11 +471,11 @@ Returns the first element of an array. Passing n will return the first n element
   // => [1, 2]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.slice()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  |  ✔  |  1.0 ✔  |  ✔  |  ✔  | ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -415,14 +491,28 @@ Flattens array a single level deep.
   // Native
   const flatten = [1, [2, [3, [4]], 5]].reduce( (a, b) => a.concat(b), [])
   // => [1, 2, [3, [4]], 5]
+  
+  const flatten = [].concat(...[1, [2, [3, [4]], 5]])
+  // => [1, 2, [3, [4]], 5]
 
+  // Native(ES2019)
+  const flatten = [1, [2, [3, [4]], 5]].flat()
+  // => [1, 2, [3, [4]], 5]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reduce()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  46.0 ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: |  :-: |
+  46.0 ✔ |  ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4 ✔ |
+
+#### Browser Support for `Array.prototype.flat()`
+
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image] |
+:-: | :-: | :-: | :-: | :-: | :-: |
+69 ✔ | ✖ | 62 ✔ | ✖ | 56 ✔ | 12 ✔ |
+
 
 **[⬆ back to top](#quick-links)**
 
@@ -442,13 +532,25 @@ Recursively flattens array.
 
   flattenDeep([1, [[2], [3, [4]], 5]])
   // => [1, 2, 3, 4, 5]
+  
+  // Native(ES2019)
+  [1, [2, [3, [4]], 5]].flat(Infinity)
+  // => [1, 2, 3, 4, 5]
+  
   ```
 
 #### Browser Support
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  46.0 ✔ | 16.0 ✔ |  Not supported  |  37.0 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  46.0 ✔ |  ✔ | 16.0 ✔ |  ✖  |  37.0 ✔ |  7.1 ✔ |
+
+
+#### Browser Support for `Array.prototype.flat()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image] |
+:-: | :-: | :-: | :-: | :-: | :-: |
+69 ✔ | ✖ | 62 ✔ | ✖ | 56 ✔ | 12 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -476,11 +578,11 @@ Returns an object composed from key-value pairs.
   // => { 'a': 1, 'b': 2 }
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reduce()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 3.0 ✔ |  9 ✔  |  10.5 ✔ |  4.0 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -509,11 +611,11 @@ Gets the first element or all but the first element.
   // output [2, 3]
   ```
 
-#### Browser Support
+#### Browser Support for Spread in array literals
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  49 ✔  |  34 ✔ |  Not Supported |  37 ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  46.0 ✔  | 12.0 ✔ |  16.0 ✔ |  ✖ |  37.0 ✔ | 8.0 ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -535,11 +637,132 @@ Returns the first index at which a given element can be found in the array, or -
   // output: 0
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.indexOf()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔  |  1.5 ✔ |  9.0 ✔  |  ✔  |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.intersection
+Returns an array that is the intersection of all the arrays. Each value in the result is present in each of the arrays.
+
+  ```js
+  // Underscore/Lodash
+  console.log(_.intersection([1, 2, 3], [101, 2, 1, 10], [2, 1]))
+  // output: [1, 2]
+
+  // Native
+  var arrays = [[1, 2, 3], [101, 2, 1, 10], [2, 1]];
+  console.log(array.reduce(function(a, b) {
+    return a.filter(function(value) {
+      return b.includes(value);
+    });
+  })));
+  // output: [1, 2]
+
+  // ES6
+  let arrays = [[1, 2, 3], [101, 2, 1, 10], [2, 1]];
+  console.log(arrays.reduce((a, b) => a.filter(c => b.includes(c))));
+  // output: [1, 2]
+  ```
+
+#### Browser Support for `Array.prototype.reduce()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.takeRight
+
+Creates a slice of array with n elements taken from the end. 
+:heavy_exclamation_mark: Native slice does not behave entirely the same as the `Lodash` method. See example below to understand why.
+
+  ```js
+  // Underscore/Lodash
+  _.takeRight([1, 2, 3]);
+  // => [3]
+  
+  _.takeRight([1, 2, 3], 2);
+  // => [2, 3]
+  
+  _.takeRight([1, 2, 3], 5);
+  // => [1, 2, 3]
+
+  // Native
+  [1, 2, 3].slice(-1);
+  // => [3]
+  
+  [1, 2, 3].slice(-2);
+  // => [2, 3]
+
+  [1, 2, 3].slice(-5);
+  // => [1, 2, 3]
+
+  // Difference in compatibility
+  
+  // Lodash
+  _.takeRight([1, 2, 3], 0);
+  // => []
+
+  // Native
+  [1, 2, 3].slice(0);
+  // => [1, 2, 3]
+  ```
+
+#### Browser Support for `Array.prototype.slice()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  |  ✔  |  1.0 ✔  |  ✔  |  ✔  | ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.isArray
+Returns true if given value is an array.
+
+  ```js
+  // Lodash
+  var array = []
+  console.log(_.isArray(array))
+  // output: true
+
+  // Native
+  var array = []
+  console.log(Array.isArray(array));
+  // output: true
+  ```
+
+  #### Browser Support for `Array.isArray()`
+
+ ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+ :-: | :-: | :-: | :-: | :-: | :-: |
+  5.0 ✔  |  ✔  | 4.0 ✔  |  9.0 ✔  |  10.5 ✔  | 5.0 ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.isArrayBuffer
+
+Checks if value is classified as an ArrayBuffer object.
+
+  ```js
+  // Lodash
+  _.isArrayBuffer(new ArrayBuffer(2));
+  // output: true
+
+  // Native
+  console.log(new ArrayBuffer(2) instanceof ArrayBuffer);
+  // output: true
+  ```
+
+  #### Browser Support for `instanceof`
+
+ ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+ :-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔  | 1.0 ✔  | ✔  | ✔  | ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -559,11 +782,11 @@ Joins a list of elements in an array with a given separator.
   // output: 'one--two--three'
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.join()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  1.0 ✔  |  1.0 ✔ |  5.5 ✔  |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  |   ✔  | 1.0 ✔ |  5.5 ✔  |  ✔ |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -599,11 +822,11 @@ Returns the last element of an array. Passing n will return the last n elements 
   // => [4, 5]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.concat()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  |  ✔  | 1.0 ✔  | 5.5 ✔  |  ✔  | ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -625,11 +848,11 @@ Returns the index of the last occurrence of value in the array, or -1 if value i
   // output: 2
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.lastIndexOf()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | 1.5 ✔  | 9.0 ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -655,11 +878,34 @@ Voice from the Lodash author:
 It's exposed on _ because previously, like `Underscore`, it was only exposed in the chaining syntax.
 >--- [jdalton](https://github.com/cht8687/You-Dont-Need-Lodash-Underscore/commit/22c4bcf2be48dd415d2b073759805562e520b615#)
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reverse()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  1.0 ✔  |  1.0 ✔ |  5.5 ✔ |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.5 ✔ |  9 ✔ |  ✔ |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.slice
+Returns a shallow copy of a portion of an array into a new array object selected from `begin` to `end` (`end` not included)
+
+  ```js
+  // Lodash
+  var array = [1, 2, 3, 4]
+  console.log(_.slice(array, 1, 3))
+  // output: [2, 3]
+
+  // Native
+  var array = [1, 2, 3, 4]
+  console.log(array.slice(1, 3));
+  // output: [2, 3]
+  ```
+
+#### Browser Support for `Array.prototype.slice()`
+
+ ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+ :-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  |  ✔  |  1.0 ✔  |  ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -681,141 +927,11 @@ Returns an array where matching items are filtered.
   // output: [1, 3]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.filter()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  1.0 ✔  |  1.5 ✔ |  9 ✔ |  ✔ |  ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.intersection
-Returns an array that is the intersection of all the arrays. Each value in the result is present in each of the arrays.
-
-  ```js
-  // Underscore/Lodash
-  console.log(_.intersection([1, 2, 3], [101, 2, 1, 10], [2, 1]))
-  // output: [1, 2]
-
-  // Native
-  var arrays = [[1, 2, 3], [101, 2, 1, 10], [2, 1]];
-  console.log(array.reduce(function(a, b) {
-    return a.filter(function(value) {
-      return b.includes(value);
-    });
-  })));
-  // output: [1, 2]
-
-  // ES6
-  let arrays = [[1, 2, 3], [101, 2, 1, 10], [2, 1]];
-  console.log(arrays.reduce((a, b) => a.filter(c => b.includes(c))));
-  // output: [1, 2]
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  1.0 ✔  |  1.5 ✔ |  9 ✔ |  ✔ |  ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.difference
-Similar to [without](#_without), but returns the values from array that are not present in the other arrays.
-
-  ```js
-  // Underscore/Lodash
-  console.log(_.difference([1, 2, 3, 4, 5], [5, 2, 10]))
-  // output: [1, 3, 4]
-
-  // Native
-  var arrays = [[1, 2, 3, 4, 5], [5, 2, 10]];
-  console.log(array.reduce(function(a, b) {
-    return a.filter(function(value) {
-      return !b.includes(value);
-    });
-  })));
-  // output: [1, 3, 4]
-
-  // ES6
-  let arrays = [[1, 2, 3, 4, 5], [5, 2, 10]];
-  console.log(arrays.reduce((a, b) => a.filter(c => !b.includes(c))));
-  // output: [1, 3, 4]
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  1.0 ✔  |  1.5 ✔ |  9 ✔ |  ✔ |  ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.slice
-Returns a shallow copy of a portion of an array into a new array object selected from `begin` to `end` (`end` not included)
-
-  ```js
-  // Lodash
-  var array = [1, 2, 3, 4]
-  console.log(_.slice(array, 1, 3))
-  // output: [2, 3]
-
-  // Native
-  var array = [1, 2, 3, 4]
-  console.log(array.slice(1, 3));
-  // output: [2, 3]
-  ```
-
-#### Browser Support
-
- ![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
- :-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.isArray
-Returns true if given value is an array.
-
-  ```js
-  // Lodash
-  var array = []
-  console.log(_.isArray(array))
-  // output: true
-
-  // Native
-  var array = []
-  console.log(Array.isArray(array));
-  // output: true
-  ```
-
-  #### Browser Support
-
- ![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
- :-: | :-: | :-: | :-: | :-: |
-  5 ✔  |  4 ✔  |  9 ✔  |  10.5 ✔  | 5 ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.isArrayBuffer
-
-Checks if value is classified as an ArrayBuffer object.
-
-  ```js
-  // Lodash
-  _.isArrayBuffer(new ArrayBuffer(2));
-  // output: true
-
-  // Native
-  console.log(new ArrayBuffer(2) instanceof ArrayBuffer);
-  // output: true
-  ```
-
-  #### Browser Support
-
- ![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
- :-: | :-: | :-: | :-: | :-: |
-  ✔  |  1 ✔  | ✔  | ✔  | ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  | ✔ | 1.5 ✔ |  9 ✔ |  ✔ |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -843,11 +959,11 @@ Iterates over a list of elements, yielding each in turn to an iteratee function.
   // output: 1 2 3
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.forEach()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.5 ✔ |  9.0 ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -876,11 +992,11 @@ Tests whether all elements in the array pass the test implemented by the provide
   // output: true
   ```
 
-#### Browser Support
+#### Browser Support fpr `Array.prototype.every()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.5 ✔ |  9.0 ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -908,11 +1024,11 @@ Creates a new array with all elements that pass the test implemented by the prov
   // output: [12, 130, 44]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.filter()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -944,11 +1060,11 @@ Group items by key.
   // output: {1: [1.3], 2: [2.1, 2.4]}
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reduce()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 3.0 ✔ |  9 ✔  |  10.5 ✔ |  4.0 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔  | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -975,15 +1091,54 @@ Checks if a value is in collection.
 
 #### Browser Support for `Array.prototype.includes`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  47 ✔  | 43 ✔ |  Not supported  |  34 ✔ |  9 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  47.0 ✔  | 14.0 ✔ | 43.0 ✔ |  ✖  |  34.0 ✔ |  9.0 ✔ |
 
 #### Browser Support for `Array.prototype.indexOf`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔ | ✔ | ✔ | ✔ | ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔ | ✔ | 1.5 ✔ | 9.0 ✔ | ✔ | ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.keyBy
+:heavy_exclamation_mark: `Lodash only`
+Creates an object composed of keys generated from the results of running each element of collection through iteratee.
+
+  ```js
+  // Lodash
+  console.log(_.keyBy(['a', 'b', 'c']))
+  // output: { a: 'a', b: 'b', c: 'c' }
+  console.log(_.keyBy([{ id: 'a1', title: 'abc' }, { id: 'b2', title: 'def' }], 'id')
+  // output: { a1: { id: 'a1', title: 'abc' }, b2: { id: 'b2', title: 'def' } }
+  console.log(_.keyBy({ data: { id: 'a1', title: 'abc' }}, 'id')
+  // output: { a1: { id: 'a1', title: 'abc' }}
+
+  // keyBy for array only
+  const keyBy = (array, key) => (array || []).reduce((r, x) => ({ ...r, [key ? x[key] : x]: x }), {});
+
+  // Native
+  console.log(keyBy(['a', 'b', 'c']))
+  // output: { a: 'a', b: 'b', c: 'c' }
+  console.log(keyBy([{ id: 'a1', title: 'abc' }, { id: 'b2', title: 'def' }], 'id')
+  // output: { a1: { id: 'a1', title: 'abc' }, b2: { id: 'b2', title: 'def' } }
+  console.log(keyBy(Object.values({ data: { id: 'a1', title: 'abc' }}), 'id')
+  // output: { a1: { id: 'a1', title: 'abc' }}
+
+  // keyBy for array and object
+  const collectionKeyBy = (collection, key) => { 
+    const c = collection || {};
+    return c.isArray() ? keyBy(c, key) : Object.values(keyBy(c, key));
+  }
+  ```
+
+#### Browser Support for `Array.prototype.reduce()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | 12.0 ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1008,6 +1163,14 @@ Translates all items in an array or object to new array of items.
   console.log(array2)
   // output: [2, 4, 6]
   ```
+
+#### Browser Support for `Array.prototype.map()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.5 ✔ |  9.0 ✔  |  ✔ |  ✔ |
+
+**[⬆ back to top](#quick-links)**
 
 ### _.minBy and _.maxBy
 
@@ -1056,11 +1219,11 @@ Extract a functor and use es2015 for better code
   // output: { value: 2 }
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reduce()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 3.0 ✔ |  9 ✔  |  10.5 ✔ |  4.0 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1084,11 +1247,11 @@ Extract a functor and use es2015 for better code
   // output: ["Alice", "Bob", "Jeremy"]
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.map()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | 1.5 ✔ |  9.0 ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1114,11 +1277,11 @@ Applies a function against an accumulator and each value of the array (from left
   // output: 10
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reduce()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 3.0 ✔ |  9 ✔  |  10.5 ✔ |  4.0 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] |  ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1147,17 +1310,17 @@ Creates an array of numbers progressing from start up to.
   ```
 
 
-#### Browser Support ( Array.from )
+#### Browser Support for `Array.from()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
- 45 ✔  | 32 ✔ |  Not supported   |  ✔ |  9.0 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+ 45.0 ✔  |  ✔ |  32.0 ✔ |  ✖   |  ✔ |  9.0 ✔ |
 
-#### Browser Support ( keys and array spread )
+#### Browser Support for keys and spread in Array literals
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
- 46 ✔  | 16 ✔ |  Not supported | 37 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+ 46.0 ✔  |  12.0 ✔ |  16.0 ✔ |  ✖ | 37.0 ✔ |  7.1 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1183,11 +1346,42 @@ This method is like _.reduce except that it iterates over elements of collection
   // output: -2
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.reduceRight()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 3.0 ✔ |  9 ✔  |  10.5 ✔ |  4.0 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.sample
+
+Gets a random element from `array`.
+
+  ```js
+  // Underscore/Lodash
+  const array = [0, 1, 2, 3, 4]
+  const result = _.sample(array)
+  console.log(result)
+  // output: 2
+
+  // Native
+  const array = [0, 1, 2, 3, 4]
+  const sample = arr => {
+    const len = arr == null ? 0 : arr.length
+    return len ? arr[Math.floor(Math.random() * len)] : undefined
+  }
+
+  const result = sample(array)
+  console.log(result)
+  // output: 2
+  ```
+
+#### Browser Support for `Array.prototype.length()` and `Math.random()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.0 ✔ |  ✔  |  ✔ |  ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1207,11 +1401,11 @@ Returns the number of values in the collection.
   // output: 3
   ```
 
-#### Browser Support
+#### Browser Support for `Object.keys()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  5 ✔  | 4.0 ✔ |  9 ✔ |  12 ✔ |  5 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  5.0 ✔  | ✔ | 4.0 ✔ |  9.0 ✔ |  12.0 ✔ |  5.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1240,11 +1434,11 @@ Tests whether any of the elements in the array pass the test implemented by the 
   // output: true
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.some()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  38 ✔  | 13 ✔ |  Not Supported  |  25 ✔  | 9 ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.5 ✔ |  ✔ 9.0  |  ✔  | ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1273,9 +1467,19 @@ Sorts an array of object based on an object key provided by a parameter (note th
     return (a, b) => (a[key] > b[key]) ? 1 : ((b[key] > a[key]) ? -1 : 0);
   };
 
-  fruits.sort(sortBy("name"));
+  // The native sort modifies the array in place. `_.orderBy` and `_.sortBy` do not, so we use `.concat()` to
+  // copy the array, then sort.
+  fruits.concat().sort(sortBy("name"));
   // => [{name:"apple", amount: 4}, {name:"banana", amount: 2}, {name:"mango", amount: 1}, {name:"pineapple", amount: 2}]
   ```
+
+#### Browser Support for `Array.prototype.concat()` and `Array.prototype.sort()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  1.0 ✔  | ✔ | 1.0 ✔ |  5.5 ✔  |  ✔  |  ✔  |
+
+**[⬆ back to top](#quick-links)**
 
 ### _.uniq
 
@@ -1289,17 +1493,17 @@ Produces a duplicate-free version of the array, using === to test object equalit
   // output: [1, 2, 4, 3]
 
   // Native
-  var array = [1, 1, 2, 3, 4, 4, 4];
-  var result = array.filter((v, i, a) => a.indexOf(v) === i);
+  var array = [1, 2, 1, 4, 1, 3];
+  var result = [...new Set(array)];
   console.log(result)
-  // output: [1, 2, 3, 4]
+  // output: [1, 2, 4, 3]
   ```
 
-#### Browser Support
+#### Browser Support for Spread in array literals
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1.5 ✔ |  9 ✔  |  ✔  |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+ 46.0  ✔  | 12.0 ✔ | 16.0 ✔ |  ✖  |  37.0 ✔  |  8.0 ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1327,11 +1531,11 @@ Creates a version of the function that will only be run after first being called
   })
   ```
 
-#### Browser Support
+#### Browser Support for `Array.prototype.forEach()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
- :-: | :-: | :-: | :-: | :-: |
-   ✔  |  ✔ |  ✔ |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+ :-: | :-: | :-: | :-: | :-: | :-: |
+   ✔  |  ✔ |  1.5 ✔ |  9.0 ✔ |  ✔  | ✔  |
 
  **[⬆ back to top](#quick-links)**
 
@@ -1357,11 +1561,11 @@ Create a new function that calls _func_ with _thisArg_ and _args_.
   var boundOffsetX = objA.offsetX.bind(objB, 0);
   ```
 
-#### Browser Support
+#### Browser Support for `Function.prototype.bind()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
- :-: | :-: | :-: | :-: | :-: |
-   ✔  |  ✔ |  9 ✔ |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+ :-: | :-: | :-: | :-: | :-: | :-: |
+  7.0 ✔  |  ✔ | 4.0 ✔ |  9.0 ✔ |  11.6 ✔ |  5.1 ✔  |
 
  **[⬆ back to top](#quick-links)**
 
@@ -1373,24 +1577,173 @@ Create a new function that calls _func_ with _args_.
   function greet(greeting, name) {
     return greeting + ' ' + name;
   }
-  var sayHelloTo = _.partial(greet, 'hello');
+  var sayHelloTo = _.partial(greet, 'Hello');
+  var result = sayHelloTo('Jose')
+  console.log(result)
+  // output: 'Hello Jose'
 
   // Native
   function greet(greeting, name) {
     return greeting + ' ' + name;
   }
-  var sayHelloTo = (...args) => greet('hello', ...args)
+  var sayHelloTo = (...args) => greet('Hello', ...args)
+  var result = sayHelloTo('Jose')
+  console.log(result)
+  // output: 'Hello Jose'
+  
+  // Native
+  const partial = (func, ...boundArgs) => (...remainingArgs) => func(...boundArgs, ...remainingArgs)
+  var sayHelloTo = partial(greet, 'Hello');
+  var result = sayHelloTo('Jose')
+  console.log(result)
+  // output: 'Hello Jose'
   ```
 
-#### Browser Support
+#### Browser Support for Spread
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  62 ✔  | 56 ✔ |  ✗  |  49 ✔ |  11 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  46.0 ✔ | 12.0 ✔ | 16.0 ✔ |  ✖  |  37.0 ✔ |  8.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
 ## Lang
+
+### _.gt
+
+Checks if value is greater than other.
+
+```js
+// Lodash
+console.log(_.gt(3, 1))
+// output: true
+
+// Native
+console.log(3 > 1);
+// output: true
+```
+
+#### Browser Support
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | ✔ |  ✔  | ✔ | ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.gte
+
+Checks if value is greater than or equal to other.
+
+```js
+// Lodash
+console.log(_.gte(3, 1))
+// output: true
+
+// Native
+console.log(3 >= 1);
+// output: true
+```
+
+#### Browser Support
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | ✔ |  ✔  | ✔ | ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.isEmpty
+
+Checks if value is an empty object or collection.
+:heavy_exclamation_mark:`Note this is not evaluating a Set or a Map`
+
+  ```js
+  // Lodash
+  console.log(_.isEmpty(null)
+  // output: true
+  console.log(_.isEmpty('')
+  // output: true
+  console.log(_.isEmpty({})
+  // output: true
+  console.log(_.isEmpty([])
+  // output: true
+  console.log(_.isEmpty({a: '1'})
+  // output: false
+
+  // Native
+  const isEmpty = obj => [Object, Array].includes((obj || {}).constructor) && !Object.entries((obj || {})).length;
+
+  console.log(isEmpty(null)
+  // output: true
+  console.log(isEmpty('')
+  // output: true
+  console.log(isEmpty({})
+  // output: true
+  console.log(isEmpty([])
+  // output: true
+  console.log(isEmpty({a: '1'})
+  // output: false
+  ```
+
+#### Browser Support for `Array.prototype.includes()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+   47.0 ✔  | 14.0 ✔ | 43.0 ✔ |  ✖ |  34.0 ✔ |  9.0 ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+
+### _.isFinite
+
+Converts value to a finite number.
+
+  ```js
+  // Lodash
+  console.log(_.isFinite('3'))
+  // output: false
+  console.log(_.isFinite(3))
+  // output: true
+
+  // Native
+  console.log(Number.isFinite('3'))
+  // output: false
+  console.log(Number.isFinite(3))
+  // output: true
+  ```
+#### Browser Support for `Number.isFinite()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  19.0 ✔  |  ✔ | 16.0 ✔ |  ✖  |  15.0 ✔ |  9.0 ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.isInteger
+
+Checks if value is an integer.
+
+  ```js
+  // Lodash
+  console.log(_.isInteger(3))
+  // output: true
+  console.log(_.isInteger('3'))
+  // output: false
+
+  // Native
+  console.log(Number.isInteger(3))
+  // output: true
+  console.log(Number.isInteger('3'))
+  // output: false
+  ```
+#### Browser Support for `Number.isInteger()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  12 ✔ | 16.0 ✔ |  ✖  |  ✔ |  ✔ |
+
+**[⬆ back to top](#quick-links)**
 
 ### _.isNaN
 
@@ -1419,15 +1772,15 @@ Voice from the Lodash author:
 
 #### Browser Support for `isNaN`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  ✔ |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ |  1.0 ✔ |  ✔ |  ✔ |  ✔  |
 
 #### Browser Support for `Number.isNaN`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  25 ✔ | 15 ✔ |  Not supported |  ✔ |  9 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  25.0 ✔ | ✔ |  15.0 ✔ |  ✖ |  ✔ |  9.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1441,19 +1794,23 @@ console.log(_.isNil(null))
 // output: true
 console.log(_.isNil(NaN))
 // output: false
+console.log(_.isNil(undefined))
+// output: true
 
 // Native
 console.log(null == null);
 // output: true
 console.log(NaN == null);
 // output: false
+console.log(undefined == null)
+// output: true
 ```
 
 #### Browser Support
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  ✔  | ✔ | ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | ✔ |  ✔  | ✔ | ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1477,9 +1834,9 @@ console.log(void 0 === null);
 
 #### Browser Support
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  ✔  | ✔ | ✔ |
+![Chrome][chrome-image] |  ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | ✔ |  ✔  | ✔ | ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1501,53 +1858,9 @@ console.log(a === undefined);
 
 #### Browser Support
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | 1 ✔ |  ✔  | ✔ | ✔ |
-
-**[⬆ back to top](#quick-links)**
-
-### _.gt
-
-Checks if value is greater than other.
-
-```js
-// Lodash
-console.log(_.gt(3, 1))
-// output: true
-
-// Native
-console.log(3 > 1);
-// output: true
-```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | ✔ |  ✔  | ✔ | ✔ |
-
-**[⬆ back to top](#quick-links)**
-
-### _.gte
-
-Checks if value is greater than or equal to other.
-
-```js
-// Lodash
-console.log(_.gte(3, 1))
-// output: true
-
-// Native
-console.log(3 >= 1);
-// output: true
-```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | ✔ |  ✔  | ✔ | ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1 ✔ |  ✔  | ✔ | ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1586,13 +1899,105 @@ The method is used to copy the values of all enumerable own properties from one 
   // output: { 'c': 3, 'e': 5 }
   ```
 
-#### Browser Support
+#### Browser Support for `Object.assign()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  45 ✔  |  34 ✔ |  No support  |  32 ✔ |  9 ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  45.0 ✔  | ✔ | 34.0 ✔ |  ✖  |  32.0 ✔ |  9.0 ✔  |
 
  **[⬆ back to top](#quick-links)**
+
+### _.extend
+
+The method is used to copy the values of all enumerable own and inherited properties from one or more source objects to a target object.
+
+  ```js
+  // Underscore
+  // Lodash: _.assignIn
+  function Foo() {
+    this.c = 3;
+  }
+  function Bar() {
+    this.e = 5;
+  }
+  Foo.prototype.d = 4;
+  Bar.prototype.f = 6;
+  var result = _.extend({}, new Foo, new Bar);
+  console.log(result);
+  // output: { 'c': 3, 'd': 4, 'e': 5, 'f': 6 }
+
+  // Native
+  function Foo() {
+    this.c = 3;
+  }
+  function Bar() {
+    this.e = 5;
+  }
+  Foo.prototype.d = 4;
+  Bar.prototype.f = 6;
+  var result = Object.assign({}, new Foo, Foo.prototype, new Bar, Bar.prototype);
+  console.log(result);
+  // output: { 'c': 3, 'd': 4, 'e': 5, 'f': 6 }
+
+  //Or using a function
+  const extend = (target, ...sources) => {
+    let source = [];
+    sources.forEach(src => {
+      source = source.concat([src, Object.getPrototypeOf(src)])
+    })
+    return Object.assign(target, ...source)
+  };
+  console.log(extend({}, new Foo, new Bar));
+  // output: { 'c': 3, 'd': 4, 'e': 5, 'f': 6 }
+  ```
+
+#### Browser Support for `Object.assign()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  45.0 ✔  | ✔ | 34.0 ✔ |  ✖  |  32.0 ✔ |  9.0 ✔  |
+
+ **[⬆ back to top](#quick-links)**
+
+ ### _.get
+
+Gets the value at path of object.
+*Note: If provided path does not exists inside the object js will generate error.*
+
+  ```js
+  // Lodash
+  var object = { a: [{ b: { c: 3 } }] };
+  var result = _.get(object, 'a[0].b.c', 1);
+  console.log(result);
+  // output: 3
+
+  // Native (ES6 - IE not supported)
+  var object = { a: [{ b: { c: 3 } }] };
+  var { a: [{ b: { c: result2 = 1 } }] } = object;
+  console.log(result2);
+  // output: 3
+  
+  // Native
+  const get = (obj, path, defaultValue) => {
+    const result = String.prototype.split.call(path, /[,[\].]+?/)
+      .filter(Boolean)
+      .reduce((res, key) => (res !== null && res !== undefined) ? res[key] : res, obj);
+    return (result === undefined || result === obj) ? defaultValue : result;
+  }
+  
+  var object = { a: [{ b: { c: 3 } }] };
+  var result = get(object, 'a[0].b.c', 1); 
+  // output: 3
+  
+  ```
+
+#### Browser Support for Object destructing
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  49.0 ✔  | 14.0 ✔ |  41.0 ✔ |  ✖  |  41.0 ✔ |  8.0 ✔ |
+
+  **[⬆ back to top](#quick-links)**
 
 ### _.keys
 
@@ -1610,88 +2015,14 @@ Retrieves all the names of the object's own enumerable properties.
   // output: ["one", "two", "three"]
   ```
 
-#### Browser Support
+#### Browser Support for `Object.keys()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  5 ✔  | 4.0 ✔ |  9 ✔ |  12 ✔ |  5 ✔ |
-
-**[⬆ back to top](#quick-links)**
-
-### _.toPairs
-
-Retrieves all the given object's own enumerable property `[ key, value ]` pairs.
-
-  ```js
-  // Underscore - also called _.pairs
-  // Lodash - also called _.entries
-  var result = _.toPairs({one: 1, two: 2, three: 3})
-  console.log(result)
-  // output: [["one", 1], ["two", 2], ["three", 3]]
-
-  // Native
-  var result2 = Object.entries({one: 1, two: 2, three: 3})
-  console.log(result2)
-  // output: [["one", 1], ["two", 2], ["three", 3]]
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  38 ✔  | 28 ✔ |  Not supported  |  25 ✔ |  7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: |  :-: |
+  5.0 ✔  | ✔ | 4.0 ✔ |  9.0 ✔ |  12.0 ✔ |  5.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
-### _.values
-
-Retrieves all the given object's own enumerable property values.
-
-  ```js
-  // Underscore/Lodash
-  var result = _.values({one: 1, two: 2, three: 3})
-  console.log(result)
-  // output: [1, 2, 3]
-
-  // Native
-  var result2 = Object.values({one: 1, two: 2, three: 3})
-  console.log(result2)
-  // output: [1, 2, 3]
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  54 ✔  | 47 ✔ |  Not supported  |  41.0 ✔ |  10.1 ✔ |
-
-**[⬆ back to top](#quick-links)**
-
-### _.get
-
-Gets the value at path of object.
-*Note: If provided path does not exists inside the object js will generate error.*
-
-  ```js
-  // Lodash
-  var object = { a: [{ b: { c: 3 } }] };
-  var result = _.get(object, 'a[0].b.c', 1);
-  console.log(result);
-  // output: 3
-
-  // Native
-  var object = { a: [{ b: { c: 3 } }] };
-  var { a: [{ b: { c: result2 = 1 } }] } = object;
-  console.log(result2);
-  // output: 3
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  49 ✔  | 41 ✔ |  Not supported  |  41.0 ✔ |  8 ✔ |
-  
 ### _.omit
 
 Returns a copy of the object, filtered to omit the keys specified.
@@ -1710,11 +2041,11 @@ Returns a copy of the object, filtered to omit the keys specified.
   // output: { 'b': '2' }
   ```
 
-#### Browser Support
+#### Browser Support for Spread in object literals
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  60 ✔  | 55 ✔ |  Not supported  |  37 ✔ | Not Supported |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  60.0 ✔ | ✖ | 55.0 ✔ |  ✖ |  37.0 ✔ | ✖ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1723,7 +2054,7 @@ Returns a copy of the object, filtered to omit the keys specified.
 Creates an object composed of the object properties predicate returns truthy for.
 
   ```js
- var object = { 'a': 1, 'b': '2', 'c': 3 };
+  var object = { 'a': 1, 'b': '2', 'c': 3 };
 
   // Underscore/Lodash
   var result = _.pick(object, ['a', 'c']);
@@ -1731,15 +2062,21 @@ Creates an object composed of the object properties predicate returns truthy for
   // output: {a: 1, c: 3}
 
   // Native
-  function pick(object, paths) {
-      const obj = {};
-      for (const path of paths) {
-        if (object[path]) {
-          obj[path] = object[path]
-        }
-      }
-      return obj;
-  } 
+  const { a, c } = object;
+  const result = { a, c};
+  console.log(result);
+  // output: {a: 1, c: 3}
+  // for an array of this object --> array.map(({a, c}) => ({a, c}));
+
+  // Native
+  function pick(object, keys) {
+    return keys.reduce((obj, key) => {
+       if (object && object.hasOwnProperty(key)) {
+          obj[key] = object[key];
+       }
+       return obj;
+     }, {});
+  }
   var result = pick(object, ['a', 'c']);
   console.log(result)
   // output: {a: 1, c: 3}
@@ -1747,9 +2084,9 @@ Creates an object composed of the object properties predicate returns truthy for
 
 #### Browser Support
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  38 ✔  | 13 ✔ |  12 ✔  |  25 ✔ | 7.1 ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  38.0 ✔ | ✔ | 13.0 ✔ |  12.0 ✔  |  25.0 ✔ | 7.1 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1782,13 +2119,114 @@ Creates an object composed of the object properties predicate returns truthy for
 
 #### Browser Support
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  | ✔ |  6 ✔  | ✔ | ✔ |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: |  :-: |
+  ✔  | ✔ |  ✔ | 6.0 ✔  | ✔ | ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.toPairs
+
+Retrieves all the given object's own enumerable property `[ key, value ]` pairs.
+
+  ```js
+  // Underscore - also called _.pairs
+  // Lodash - also called _.entries
+  var result = _.toPairs({one: 1, two: 2, three: 3})
+  console.log(result)
+  // output: [["one", 1], ["two", 2], ["three", 3]]
+
+  // Native
+  var result2 = Object.entries({one: 1, two: 2, three: 3})
+  console.log(result2)
+  // output: [["one", 1], ["two", 2], ["three", 3]]
+  ```
+
+#### Browser Support for `Object.entries()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  54.0 ✔  | 14.0 ✔  | 47.0 ✔ |  ✖  |  41.0 ✔ |  10.1 ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.values
+
+Retrieves all the given object's own enumerable property values.
+
+  ```js
+  // Underscore/Lodash
+  var result = _.values({one: 1, two: 2, three: 3})
+  console.log(result)
+  // output: [1, 2, 3]
+
+  // Native
+  var result2 = Object.values({one: 1, two: 2, three: 3})
+  console.log(result2)
+  // output: [1, 2, 3]
+  ```
+
+#### Browser Support for `Object.values()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  54.0 ✔  | 14.0 ✔ |  47.0 ✔ |  ✖  |  41.0 ✔ |  10.1 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
 ## String
+
+### _.padStart and _.padEnd
+:heavy_exclamation_mark:`Lodash only`
+Pads the current string with another string (multiple times, if needed) until the resulting string reaches the given length.
+
+  ```js
+  // Lodash
+  console.log(_.padStart('123', 5, '0'))
+  // output: '00123'
+
+  console.log(_.padEnd('123', 5, '0'))
+  // output: '12300'
+
+  // Native
+  console.log('123'.padStart(5, '0'))
+  // output: '00123'
+
+  console.log('123'.padEnd(5, '0'))
+  // output: '12300'
+  ```
+
+#### Browser Support for `String.prototype.padStart()` and `String.prototype.padEnd()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  57.0 ✔  |  15.0 ✔ | 48.0 ✔ |  ✖  |  44.0 ✔ |  10.0 ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.startsWith
+:heavy_exclamation_mark:`Lodash only`
+Checks if string starts with the given target string.
+
+  ```js
+  // Lodash
+  var result = _.startsWith('abc', 'b', 1)
+  console.log(result)
+  // output: true
+
+  // Native
+  var result = 'abc'.startsWith('b', 1)
+  console.log(result)
+  // output: true
+  ```
+
+#### Browser Support for `String.prototype.startsWith()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  41.0 ✔  |  ✔ | 17.0 ✔ |  ✖  |  28.0 ✔ |  9.0 ✔ |
+
+**[⬆ back to top](#quick-links)**
 
 ### _.repeat
 :heavy_exclamation_mark:`Lodash only`
@@ -1797,6 +2235,7 @@ Repeats the given string n times.
   ```js
   // Lodash
   var result = _.repeat('abc', 2)
+  console.log(result)
   // output: 'abcabc'
 
   // Native
@@ -1805,106 +2244,11 @@ Repeats the given string n times.
   // output: 'abcabc'
   ```
 
-#### Browser Support
+#### Browser Support for `String.prototype.repeat()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  41 ✔  |  24 ✔ |  Not supported  |  28 ✔ |  9 ✔ |
-
-**[⬆ back to top](#quick-links)**
-
-### _.template
-:heavy_exclamation_mark: *Note this is an alternative implementation. Native template literals not escape html.*
-
-Create a template function.
-
-  ```js
-  // Lodash/Underscore
-  const compiled = _.template('hello <%= user %>!');
-  compiled({ 'user': 'fred' });
-
-  // Native
-  const templateLitreal = (value) => `hello ${value.user}`;
-  templateLitreal({ 'user': 'fred' });
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  41 ✔  |  34 ✔ |  Not supported  |  28 ✔ |  9 ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.toLower
-:heavy_exclamation_mark:`Lodash only`
-Lowercases a given string.
-
-  ```js
-  // Lodash
-  var result = _.toLower('FOOBAR')
-  console.log(result)
-  // output: 'foobar'
-
-  // Native
-  var result = 'FOOBAR'.toLowerCase()
-  console.log(result)
-  // output: 'foobar'
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  ✔  |  ✔ |  ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.toUpper
-:heavy_exclamation_mark:`Lodash only`
-Uppercases a given string.
-
-  ```js
-  // Lodash
-  var result = _.toUpper('foobar')
-  console.log(result)
-  // output: 'FOOBAR'
-
-  // Native
-  var result = 'foobar'.toUpperCase()
-  console.log(result)
-  // output: 'FOOBAR'
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  ✔  |  ✔ |  ✔  |
-
-**[⬆ back to top](#quick-links)**
-
-### _.trim
-:heavy_exclamation_mark:`Lodash only`
-Removes the leading and trailing whitespace characters from a string.
-
-  ```js
-  // Lodash
-  var result = _.trim(' abc ')
-  console.log(result)
-  // output: 'abc'
-
-  // Native
-  var result = ' abc '.trim()
-  console.log(result)
-  // output: 'abc'
-  ```
-
-#### Browser Support
-
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  5.0 ✔  |  3.5 ✔ |  9.0 ✔  |  10.5 ✔ |  5.0 ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  41.0 ✔  | ✔ | 24.0 ✔ |  ✖  |  28.0 ✔ |  9.0 ✔ |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1927,11 +2271,159 @@ returns a new string with some or all matches of a `pattern` replaced by a `repl
   // output: 'oranges are round, and oranges are juicy.'
   ```
 
-#### Browser Support
+#### Browser Support for `String.prototype.replace()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  ✔  |  ✔ |  ✔  |  ✔ |  ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ | 1.0 ✔ |  ✔  |  ✔ |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+  
+### _.split
+:heavy_exclamation_mark:`Lodash only`
+Splits string by separator.
+
+  ```js
+  // Lodash
+  var result = _.split('a-b-c', '-', 2)
+    console.log(result)
+  // output: ['a','b']
+
+  // Native
+  var result = 'a-b-c'.split('-', 2)
+  console.log(result)
+  // output: ['a','b']
+  ```
+
+#### Browser Support for `String.prototype.split()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ |  1.0 ✔ |  ✔  | ✔ | ✔ |
+
+**[⬆ back to top](#quick-links)**
+
+### _.template
+:heavy_exclamation_mark: *Note this is an alternative implementation. Native template literals not escape html.*
+
+Create a template function.
+
+  ```js
+  // Lodash/Underscore
+  const compiled = _.template('hello <%= user %>!');
+  var result = compiled({ 'user': 'fred' });
+  console.log(result);
+  // output: 'hello fred'
+
+  // Native
+  const templateLiteral = (value) => `hello ${value.user}`;
+  var result = templateLiteral({ 'user': 'fred' });
+  console.log(result);
+  // output: 'hello fred'
+  ```
+
+#### Browser Support for String (template) literals
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  41.0 ✔  | 12.0 ✔ | 34.0 ✔ |  ✖  |  28.0 ✔ |  9.0 ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.toLower
+:heavy_exclamation_mark:`Lodash only`
+Lowercases a given string.
+
+  ```js
+  // Lodash
+  var result = _.toLower('FOOBAR')
+  console.log(result)
+  // output: 'foobar'
+
+  // Native
+  var result = 'FOOBAR'.toLowerCase()
+  console.log(result)
+  // output: 'foobar'
+  ```
+
+#### Browser Support for `String.prototype.toLowerCase()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | 1.0 ✔ |  ✔  |  ✔ |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.toUpper
+:heavy_exclamation_mark:`Lodash only`
+Uppercases a given string.
+
+  ```js
+  // Lodash
+  var result = _.toUpper('foobar')
+  console.log(result)
+  // output: 'FOOBAR'
+
+  // Native
+  var result = 'foobar'.toUpperCase()
+  console.log(result)
+  // output: 'FOOBAR'
+  ```
+
+#### Browser Support for `String.prototype.toUpperCase()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔ | 1.0 ✔ |  ✔  |  ✔ |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.trim
+:heavy_exclamation_mark:`Lodash only`
+Removes the leading and trailing whitespace characters from a string.
+
+  ```js
+  // Lodash
+  var result = _.trim(' abc ')
+  console.log(result)
+  // output: 'abc'
+
+  // Native
+  var result = ' abc '.trim()
+  console.log(result)
+  // output: 'abc'
+  ```
+
+#### Browser Support for `String.prototype.trim()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  5.0 ✔  | ✔ |  3.5 ✔ |  9.0 ✔  |  10.5 ✔ |  5.0 ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+### _.upperFIrst
+:heavy_exclamation_mark:`Lodash only`
+Uppercases the first letter of a given string
+
+  ```js
+  // Lodash
+  var result = _.upperFirst('george')
+  console.log(result)
+  // output: 'George'
+
+  // Native
+  const upperFirst = (string) => {
+    return string ? string.charAt(0).toUpperCase() + string.slice(1) : ''
+  }
+  
+  var result = upperFirst('george')
+  console.log(result)
+  // output: 'George'
+  ```
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  | ✔ |  ✔ |  ✔  |  ✔ |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1956,11 +2448,11 @@ Removes all duplicates entries from an array.
   // output: [1, 2, 4, 3]
   ```
 
-#### Browser Support
+#### Browser Support for `new Set()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  38 ✔  |  13 ✔ |  11 ✔  |  25 ✔ |  7.1 ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  38.0 ✔  | ✔ 12.0 | 13.0 ✔ |  11.0 ✔  |  25.0 ✔ |  7.1 ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -1986,11 +2478,98 @@ Invokes the iteratee n times, returning an array of the results of each invocati
   // output: '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]'
   ```
 
-#### Browser Support
+#### Browser Support for `Array.from()`
 
-![Chrome][chrome-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: |
-  45 ✔  | 32 ✔ |  Not supported  |  ✔ | 9 ✔  |
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  45.0 ✔  | ✔ |  32.0 ✔ |  ✖  |  ✔ | 9.0 ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+## Number
+
+### _.inRange
+Checks if n is between start and up to, but not including, end. If end is not specified, it's set to start with start then set to 0. If start is greater than end the params are swapped to support negative ranges.
+
+  ```js
+    // Lodash
+    _.inRange(3, 2, 4);
+    // output: true
+    _.inRange(-3, -2, -6);
+    // output: true
+
+    //Native
+    const inRange = (num, init, final) => {
+      if(final === undefined){
+        final = init;
+        init = 0;
+      }
+      return (num >= Math.min(init, final) && num < Math.max(init, final));
+    }
+    
+    //Native
+    const inRange = (num, a, b=0) => (Math.min(a,b) <= num && num < Math.max(a,b));
+
+    inRange(3, 2, 4);
+    // output: true
+    inRange(-3, -2, -6);
+    // output: true
+  ```
+
+  #### Browser Support for `Math.min() and Math.max()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+✔  |  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+  ### _.random
+Produces a random number between the inclusive lower and upper bounds. If only one argument is provided a number between 0 and the given number is returned. If floating is true, or either lower or upper are floats, a floating-point number is returned instead of an integer.
+
+  ```js
+    // Lodash
+    _.random(0, 5);
+    // => an integer between 0 and 5
+    
+    _.random(5);
+    // => also an integer between 0 and 5
+    
+    _.random(5, true);
+    // => a floating-point number between 0 and 5
+    
+    _.random(1.2, 5.2);
+    // => a floating-point number between 1.2 and 5.2
+
+    //Native
+    const random = (lower, upper) => {
+      if(!upper || typeof upper === 'boolean') {
+        upper = lower;
+        lower = 0;
+      }
+      
+      let randomic = Math.random() * upper;
+      return randomic >= lower ? randomic : random(lower, upper);
+    }
+
+    random(0, 5);
+    // => an integer between 0 and 5
+    
+    random(5);
+    // => also an integer between 0 and 5
+    
+    random(5, true);
+    // => a floating-point number between 0 and 5
+    
+    random(1.2, 5.2);
+    // => a floating-point number between 1.2 and 5.2
+  ```
+
+  #### Browser Support for `Math.random()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -2006,8 +2585,10 @@ Invokes the iteratee n times, returning an array of the results of each invocati
 MIT
 
 
-[chrome-image]: https://raw.github.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png
-[firefox-image]: https://raw.github.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png
-[ie-image]: https://raw.github.com/alrra/browser-logos/master/src/archive/internet-explorer_9-11/internet-explorer_9-11_48x48.png
-[opera-image]: https://raw.github.com/alrra/browser-logos/master/src/opera/opera_48x48.png
-[safari-image]: https://raw.github.com/alrra/browser-logos/master/src/safari/safari_48x48.png
+[chrome-image]: https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png
+[firefox-image]: https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png
+[ie-image]: https://raw.githubusercontent.com/alrra/browser-logos/master/src/archive/internet-explorer_9-11/internet-explorer_9-11_48x48.png
+[opera-image]: https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png
+[safari-image]: https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png
+[edge-image]:
+https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png

--- a/lib/rules/rules.json
+++ b/lib/rules/rules.json
@@ -198,7 +198,7 @@
     },
     "uniq": {
         "compatible": true,
-        "alternative": "[... new Set(arr)]",
+        "alternative": "Array.prototype.filter((v, i, a) => a.indexOf(v) === i)",
         "ES6": true
     },
     "replace": {


### PR DESCRIPTION
I've found an issue with `_.uniq` and Internet Explorer (IE).

IE does not support `new Set(iterable)`

See screenshot from `mdn` below:
![screen shot 2018-11-30 at 11 30 03 am](https://user-images.githubusercontent.com/13043067/49261416-39fdb480-f496-11e8-8a4b-e2d6669de3b9.jpg)


So, I've updated the example to be IE compatible.
```
[...new Set(array)];
```

to...
```
 array.filter((v, i, a) => a.indexOf(v) === i)
```