### PR TITLE
Updated native sort example to better match Lodash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1275,7 +1275,9 @@ Sorts an array of object based on an object key provided by a parameter (note th
     return (a, b) => (a[key] > b[key]) ? 1 : ((b[key] > a[key]) ? -1 : 0);
   };
 
-  fruits.sort(sortBy("name"));
+  // The native sort modifies the array in place. `_.orderBy` and `_.sortBy` do not, so we use `.concat()` to
+  // copy the array, then sort.
+  fruits.concat().sort(sortBy("name"));
   // => [{name:"apple", amount: 4}, {name:"banana", amount: 2}, {name:"mango", amount: 1}, {name:"pineapple", amount: 2}]
   ```
 


### PR DESCRIPTION
In Lodash/Underscore `_.sortBy` and `_.orderBy` both return copies of the array. The native `sort` modifies the array in place; something that can be very unexpected if you're not familiar with the native sort. A simple `.concat()` restores the expected behavior.

I couldn't find any relevant tests to modify, so I think this is a documentation only change. If I missed something, please let me know!