### PR TITLE
Fixed spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1827,8 +1827,8 @@ Create a template function.
   compiled({ 'user': 'fred' });
 
   // Native
-  const templateLitreal = (value) => `hello ${value.user}`;
-  templateLitreal({ 'user': 'fred' });
+  const templateLiteral = (value) => `hello ${value.user}`;
+  templateLiteral({ 'user': 'fred' });
   ```
 
 #### Browser Support


### PR DESCRIPTION
In the `_.template`  section:

`templateLitreal` => `templateLiteral`