### PR TITLE
Fix broken Unit Test's

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ then Lodash/Underscore is the better option.*
 **[Number](#number)**
 
 1. [_.inRange](#_inRange)
+2. [_.random](#_random)
 
 ## Array
 
@@ -2375,6 +2376,55 @@ Checks if n is between start and up to, but not including, end. If end is not sp
   ```
 
   #### Browser Support for `Math.min() and Math.max()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+✔  |  ✔  |  ✔  |  ✔  |  ✔  |  ✔  |
+
+**[⬆ back to top](#quick-links)**
+
+  ### _.random
+Produces a random number between the inclusive lower and upper bounds. If only one argument is provided a number between 0 and the given number is returned. If floating is true, or either lower or upper are floats, a floating-point number is returned instead of an integer.
+
+  ```js
+    // Lodash
+    _.random(0, 5);
+    // => an integer between 0 and 5
+    
+    _.random(5);
+    // => also an integer between 0 and 5
+    
+    _.random(5, true);
+    // => a floating-point number between 0 and 5
+    
+    _.random(1.2, 5.2);
+    // => a floating-point number between 1.2 and 5.2
+
+    //Native
+    const random = (lower, upper) => {
+      if(!upper || typeof upper === 'boolean') {
+        upper = lower;
+        lower = 0;
+      }
+      
+      let randomic = Math.random() * upper;
+      return randomic >= lower ? randomic : random(lower, upper);
+    }
+
+    random(0, 5);
+    // => an integer between 0 and 5
+    
+    random(5);
+    // => also an integer between 0 and 5
+    
+    random(5, true);
+    // => a floating-point number between 0 and 5
+    
+    random(1.2, 5.2);
+    // => a floating-point number between 1.2 and 5.2
+  ```
+
+  #### Browser Support for `Math.random()`
 
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -249,14 +249,14 @@ describe('code snippet example', () => {
     const limit = 2;
     it(`_.split("${source}", "${separator}")`, () => {
       assert.equal(
-        _.split(source, separator),
-        source.split(separator)
+        JSON.stringify(_.split(source, separator)),
+        JSON.stringify(source.split(separator))
       );
     })
     it(`_.split("${source}", "${separator}", ${limit})`, () => {
       assert.equal(
-        _.split(source, separator, limit),
-        source.split(separator, limit)
+        JSON.stringify(_.split(source, separator, limit)),
+        JSON.stringify(source.split(separator, limit))
       );
     })
   })

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -325,4 +325,32 @@ describe('code snippet example', () => {
       )
     });
   })
+  describe('random', () => {
+    
+    const random = (lower, upper) => {
+      if(!upper || typeof upper === 'boolean') {
+        upper = lower;
+        lower = 0;
+      }
+      
+      let randomic = Math.random() * upper;
+      return randomic >= lower ? randomic : random(lower, upper);
+    }
+
+    it('_.random(0, 5)', () => {
+      assert(random(0, 5) >= 0 && random(0, 5) <= 5);
+    });
+
+    it('_.random(5)', () => {
+      assert(random(5) >= 0 && random(5) <= 5);
+    });
+
+    it('_.random(5, true)', () => {
+      assert(random(5, true) >= 0 && random(5, true) <= 5);
+    });
+
+    it('_.random(1.2, 5.2)', () => {
+      assert(random(1.2, 5.2) >= 1.2 && random(1,2, 5.2) <= 5.2);
+    });
+  });
 })

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -248,15 +248,15 @@ describe('code snippet example', () => {
     const separator = '-';
     const limit = 2;
     it(`_.split("${source}", "${separator}")`, () => {
-      assert.equal(
-        JSON.stringify(_.split(source, separator)),
-        JSON.stringify(source.split(separator))
+      assert.deepEqual(
+        _.split(source, separator),
+        source.split(separator)
       );
     })
     it(`_.split("${source}", "${separator}", ${limit})`, () => {
-      assert.equal(
-        JSON.stringify(_.split(source, separator, limit)),
-        JSON.stringify(source.split(separator, limit))
+      assert.deepEqual(
+        _.split(source, separator, limit),
+        source.split(separator, limit)
       );
     })
   })


### PR DESCRIPTION
I created this PR to correct the `._split` test's. Atually, the comparison used is based from returned Array, then, was necessary add the `JSON.stringify` function to help into test execution.