### PR TITLE
 Shorter alternative syntax for inRange and add actual native representation of partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -2412,6 +2412,9 @@ Checks if n is between start and up to, but not including, end. If end is not sp
       }
       return (num >= Math.min(init, final) && num < Math.max(init, final));
     }
+    
+    //Native
+    const inRange = (num, a, b=0) => (Math.min(a,b) <= num && num < Math.max(a,b));
 
     inRange(3, 2, 4);
     // output: true


### PR DESCRIPTION
Far shorter (and for me easier to understand) Syntax for inRange.

I'm not sure how support for defaults is, as I usually use TypeScript which Polyfills these, but you may just want to get rid of the old syntax.