### PR TITLE
feat: enable compatible-error

### DIFF
--- a/configuring.md
+++ b/configuring.md
@@ -49,6 +49,7 @@ The following options are available:
 
 - you-dont-need-lodash-underscore:all-warn (all rules set to warn)
 - you-dont-need-lodash-underscore:all (all rules set to error)
+- you-dont-need-lodash-underscore:compatible-error (rules in which the native implementation is perfectly compatible with the _ one are set to error, the rest are disabled)
 - you-dont-need-lodash-underscore:compatible-warn (rules in which the native implementation is perfectly compatible with the _ one are set to warn, the rest are disabled)
 - you-dont-need-lodash-underscore:compatible (rules in which the native implementation is perfectly compatible with _ one are set to error, the rest are set to warn)
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,13 @@ module.exports.configs = {
     rules: configure(all, ERROR)
   },
 
+  'compatible-error': {
+    plugins: [
+      'you-dont-need-lodash-underscore'
+    ],
+    rules: configure(compatible, ERROR)
+  },
+
   'compatible-warn': {
     plugins: [
       'you-dont-need-lodash-underscore'


### PR DESCRIPTION
On line 45 of [./configuring.md](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore/edit/master/configuring.md) it says....

```js
"extends" : ["plugin:you-dont-need-lodash-underscore/compatible-error"],
```

However `compatible-error` isn't set up. I think it should be because that will prevent silly inclusions in a project but not show all the warnings which you'd get with plain `"plugin:you-dont-need-lodash-underscore/compatible"`.

This PR enables `compatible-error`

Thanks, great project!