### PR TITLE
Fixes #98: Adding support for named imports

### DIFF
--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -5,15 +5,16 @@ const rules = require('./rules');
 for (const rule in rules) {
   const alternative = rules[rule].alternative;
   const ruleName = rules[rule].ruleName || kebabCase(rule);
-  const forbiddenImports = [`lodash/${rule}`, `lodash.${rule}`.toLowerCase()];
+  const forbiddenImports = { [`lodash/${rule}`]: 1, [`lodash.${rule.toLowerCase()}`]: 1 };
   module.exports[ruleName] = {
-    create (context) {
+    create(context) {
       return {
         CallExpression(node) {
           const callee = node.callee;
           const objectName = callee.name || (callee.object && callee.object.name);
 
-          if ((objectName === '_' || objectName === 'lodash' || objectName === 'underscore') && callee.property && callee.property.name === rule) {
+          if (
+            (objectName === '_' || objectName === 'lodash' || objectName === 'underscore') && callee.property && callee.property.name === rule) {
             context.report({
               node,
               message: `Consider using the native ${alternative}`
@@ -21,7 +22,19 @@ for (const rule in rules) {
           }
         },
         ImportDeclaration(node) {
-          if (forbiddenImports.indexOf(node.source.value) !== -1) {
+          if (node.source.value === 'lodash') {
+            // ex: import { indexOf } from 'lodash';
+            node.specifiers.forEach(specifier => {
+              if (specifier.type === 'ImportSpecifier' && specifier.local.name === rule) {
+                context.report({
+                  node,
+                  message: `Import { ${rule} } from '${node.source.value}' detected. Consider using the native ${alternative}`
+                });
+              }
+            });
+          } else if (forbiddenImports.hasOwnProperty(node.source.value)) {
+            // ex: import indexOf from 'lodash/indexOf';
+            // ex: import indexOf from 'lodash.indexof';
             context.report({
               node,
               message: `Import from '${node.source.value}' detected. Consider using the native ${alternative}`

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -25,6 +25,9 @@ ruleTester.run('_.concat', rules.concat, {
   }, {
     code: "import concat from 'lodash.concat';",
     errors: ["Import from 'lodash.concat' detected. Consider using the native Array.prototype.concat()"]
+  }, {
+    code: "import { concat } from 'lodash';",
+    errors: ["Import { concat } from 'lodash' detected. Consider using the native Array.prototype.concat()"]
   }]
 });
 
@@ -36,11 +39,14 @@ ruleTester.run('lodash.keys', rules.keys, {
     code: 'lodash.keys({one: 1, two: 2, three: 3})',
     errors: ['Consider using the native Object.keys()']
   }, {
-    code: "import concat from 'lodash/keys';",
+    code: "import keys from 'lodash/keys';",
     errors: ["Import from 'lodash/keys' detected. Consider using the native Object.keys()"]
   }, {
-    code: "import concat from 'lodash.keys';",
+    code: "import keys from 'lodash.keys';",
     errors: ["Import from 'lodash.keys' detected. Consider using the native Object.keys()"]
+  }, {
+    code: "import { keys } from 'lodash';",
+    errors: ["Import { keys } from 'lodash' detected. Consider using the native Object.keys()"]
   }]
 });
 
@@ -52,11 +58,14 @@ ruleTester.run('underscore.forEach', rules['for-each'], {
     code: 'underscore.forEach()',
     errors: ['Consider using the native Array.prototype.forEach()']
   }, {
-    code: "import concat from 'lodash/forEach';",
+    code: "import forEach from 'lodash/forEach';",
     errors: ["Import from 'lodash/forEach' detected. Consider using the native Array.prototype.forEach()"]
   }, {
-    code: "import concat from 'lodash.foreach';",
+    code: "import forEach from 'lodash.foreach';",
     errors: ["Import from 'lodash.foreach' detected. Consider using the native Array.prototype.forEach()"]
+  }, {
+    code: "import { forEach } from 'lodash';",
+    errors: ["Import { forEach } from 'lodash' detected. Consider using the native Array.prototype.forEach()"]
   }]
 });
 
@@ -68,11 +77,14 @@ ruleTester.run('underscore.isNaN', rules['is-nan'], {
     code: 'underscore.isNaN(NaN)',
     errors: ['Consider using the native Number.isNaN()']
   }, {
-    code: "import concat from 'lodash/isNaN';",
+    code: "import isNaN from 'lodash/isNaN';",
     errors: ["Import from 'lodash/isNaN' detected. Consider using the native Number.isNaN()"]
   }, {
-    code: "import concat from 'lodash.isnan';",
+    code: "import isNaN from 'lodash.isnan';",
     errors: ["Import from 'lodash.isnan' detected. Consider using the native Number.isNaN()"]
+  }, {
+    code: "import { isNaN } from 'lodash';",
+    errors: ["Import { isNaN } from 'lodash' detected. Consider using the native Number.isNaN()"]
   }]
 });
 


### PR DESCRIPTION
```js
import { keys } from 'lodash';
```

Should now be detected for example.
Tests were updated.