### PR TITLE
Fixes #98: Adding support for notifying on `require("lodash")`

### DIFF
--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -76,9 +76,7 @@ for (const rule in rules) {
             // ex: import indexOf from 'lodash.indexof';
             context.report({
               node,
-              message: `Import from '${
-                node.source.value
-              }' detected. Consider using the native ${alternative}`
+              message: `Import from '${node.source.value}' detected. Consider using the native ${alternative}`
             });
           }
         }

--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -2,6 +2,20 @@
 const kebabCase = require('kebab-case');
 const rules = require('./rules');
 
+function getAssignmentLeftHandSide(node) {
+  // For VariableDeclarator nodes, the left hand side is called `id`
+  // The `x` on `var x = 3;
+  if (node.type === 'VariableDeclarator') {
+    return node.id;
+  }
+  // For AssignmentExpression nodes, the left hand side is called `left`
+  // The `x` on `x = 3;
+  if (node.type === 'AssignmentExpression') {
+    return node.left;
+  }
+  return null;
+}
+
 for (const rule in rules) {
   const alternative = rules[rule].alternative;
   const ruleName = rules[rule].ruleName || kebabCase(rule);
@@ -13,8 +27,32 @@ for (const rule in rules) {
           const callee = node.callee;
           const objectName = callee.name || (callee.object && callee.object.name);
 
-          if (
-            (objectName === '_' || objectName === 'lodash' || objectName === 'underscore') && callee.property && callee.property.name === rule) {
+          if (objectName === 'require' && node.arguments.length === 1) {
+            const requiredModuleName = node.arguments[0].value;
+            const { parent } = node;
+            if (requiredModuleName === 'lodash') {
+              const leftHandSide = getAssignmentLeftHandSide(parent);
+              // ex: const { indexOf } = require('lodash');
+              // ex: ({ indexOf } = require('lodash'));
+              if (leftHandSide && leftHandSide.type === 'ObjectPattern') {
+                leftHandSide.properties.forEach(property => {
+                  if (property.key.name === rule) {
+                    context.report({
+                      node,
+                      message: `{ ${rule} } = require('${requiredModuleName}') detected. Consider using the native ${alternative}`
+                    });
+                  }
+                });
+              }
+            } else if (forbiddenImports.hasOwnProperty(requiredModuleName)) {
+              // ex: const indexOf = require('lodash.indexof');
+              // ex: const indexOf = require('lodash/indexOf');
+              context.report({
+                node,
+                message: `require('${requiredModuleName}') detected. Consider using the native ${alternative}`
+              });
+            }
+          } else if ((objectName === '_' || objectName === 'lodash' || objectName === 'underscore') && callee.property && callee.property.name === rule) {
             context.report({
               node,
               message: `Consider using the native ${alternative}`
@@ -24,8 +62,9 @@ for (const rule in rules) {
         ImportDeclaration(node) {
           if (node.source.value === 'lodash') {
             // ex: import { indexOf } from 'lodash';
+            // ex: import { indexOf as x } from 'lodash';
             node.specifiers.forEach(specifier => {
-              if (specifier.type === 'ImportSpecifier' && specifier.local.name === rule) {
+              if (specifier.type === 'ImportSpecifier' && specifier.imported.name === rule) {
                 context.report({
                   node,
                   message: `Import { ${rule} } from '${node.source.value}' detected. Consider using the native ${alternative}`
@@ -37,7 +76,9 @@ for (const rule in rules) {
             // ex: import indexOf from 'lodash.indexof';
             context.report({
               node,
-              message: `Import from '${node.source.value}' detected. Consider using the native ${alternative}`
+              message: `Import from '${
+                node.source.value
+              }' detected. Consider using the native ${alternative}`
             });
           }
         }

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -33,37 +33,30 @@ ruleTester.run('lodash.keys', rules.keys, {
   }]
 });
 
-[
-  { fnName: 'keys', alternative: 'Object.keys()' }, 
-  { fnName: 'indexOf', alternative: 'Array.prototype.indexOf()' },
-  { fnName: 'forEach', alternative: 'Array.prototype.forEach()' },
-  { fnName: 'isNaN', ruleName: 'is-nan', alternative: 'Number.isNaN()' }
-].forEach(({ fnName, ruleName, alternative }) => {
-  ruleTester.run(`Import lodash.${fnName.toLowerCase()}`, rules[ruleName || kebabCase(fnName)], {
-    valid: [],
-    invalid: [{
-      code: `import ${fnName} from 'lodash/${fnName}';`,
-      errors: [`Import from 'lodash/${fnName}' detected. Consider using the native ${alternative}`]
-    }, {
-      code: `import ${fnName} from 'lodash.${fnName.toLowerCase()}';`,
-      errors: [`Import from 'lodash.${fnName.toLowerCase()}' detected. Consider using the native ${alternative}`]
-   }, {
-      code: `import { ${fnName} as x } from 'lodash';`,
-      errors: [`Import { ${fnName} } from 'lodash' detected. Consider using the native ${alternative}`]
-    }, {
-      code: `const { ${fnName}: x } = require('lodash');`,
-      errors: [`{ ${fnName} } = require('lodash') detected. Consider using the native ${alternative}`]
-    }, {
-      code: `({ ${fnName}: x } = require('lodash'));`,
-      errors: [`{ ${fnName} } = require('lodash') detected. Consider using the native ${alternative}`]
-    }, {
-      code: `require('lodash/${fnName}');`,
-      errors: [`require('lodash/${fnName}') detected. Consider using the native ${alternative}`]
-    }, {
-      code: `require('lodash.${fnName.toLowerCase()}');`,
-      errors: [`require('lodash.${fnName.toLowerCase()}') detected. Consider using the native ${alternative}`]
-    }]
-  });
+ruleTester.run(`Import lodash.isnan`, rules['is-nan'], {
+  valid: [`{ x: require('lodash') }`],
+  invalid: [{
+    code: `import isNaN from 'lodash/isNaN';`,
+    errors: [`Import from 'lodash/isNaN' detected. Consider using the native Number.isNaN()`]
+  }, {
+    code: `import isNaN from 'lodash.isnan';`,
+    errors: [`Import from 'lodash.isnan' detected. Consider using the native Number.isNaN()`]
+  }, {
+    code: `import { isNaN as x } from 'lodash';`,
+    errors: [`Import { isNaN } from 'lodash' detected. Consider using the native Number.isNaN()`]
+  }, {
+    code: `const { isNaN: x } = require('lodash');`,
+    errors: [`{ isNaN } = require('lodash') detected. Consider using the native Number.isNaN()`]
+  }, {
+    code: `({ isNaN: x } = require('lodash'));`,
+    errors: [`{ isNaN } = require('lodash') detected. Consider using the native Number.isNaN()`]
+  }, {
+    code: `require('lodash/isNaN');`,
+    errors: [`require('lodash/isNaN') detected. Consider using the native Number.isNaN()`]
+  }, {
+    code: `require('lodash.isnan');`,
+    errors: [`require('lodash.isnan') detected. Consider using the native Number.isNaN()`]
+  }]
 });
 
 ruleTester.run('underscore.forEach', rules['for-each'], {

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -1,7 +1,6 @@
 'use strict';
 const RuleTester = require('eslint').RuleTester;
 const assert = require('assert');
-const kebabCase = require('kebab-case');
 const rules = require('../../../lib/rules/all');
 const allRules = require('../../../lib/rules/rules');
 

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -1,6 +1,7 @@
 'use strict';
 const RuleTester = require('eslint').RuleTester;
 const assert = require('assert');
+const kebabCase = require('kebab-case');
 const rules = require('../../../lib/rules/all');
 const allRules = require('../../../lib/rules/rules');
 
@@ -19,15 +20,6 @@ ruleTester.run('_.concat', rules.concat, {
   invalid: [{
     code: '_.concat(array, 2, [3], [[4]])',
     errors: ['Consider using the native Array.prototype.concat()']
-  }, {
-    code: "import concat from 'lodash/concat';",
-    errors: ["Import from 'lodash/concat' detected. Consider using the native Array.prototype.concat()"]
-  }, {
-    code: "import concat from 'lodash.concat';",
-    errors: ["Import from 'lodash.concat' detected. Consider using the native Array.prototype.concat()"]
-  }, {
-    code: "import { concat } from 'lodash';",
-    errors: ["Import { concat } from 'lodash' detected. Consider using the native Array.prototype.concat()"]
   }]
 });
 
@@ -38,16 +30,40 @@ ruleTester.run('lodash.keys', rules.keys, {
   invalid: [{
     code: 'lodash.keys({one: 1, two: 2, three: 3})',
     errors: ['Consider using the native Object.keys()']
-  }, {
-    code: "import keys from 'lodash/keys';",
-    errors: ["Import from 'lodash/keys' detected. Consider using the native Object.keys()"]
-  }, {
-    code: "import keys from 'lodash.keys';",
-    errors: ["Import from 'lodash.keys' detected. Consider using the native Object.keys()"]
-  }, {
-    code: "import { keys } from 'lodash';",
-    errors: ["Import { keys } from 'lodash' detected. Consider using the native Object.keys()"]
   }]
+});
+
+[
+  { fnName: 'keys', alternative: 'Object.keys()' }, 
+  { fnName: 'indexOf', alternative: 'Array.prototype.indexOf()' },
+  { fnName: 'forEach', alternative: 'Array.prototype.forEach()' },
+  { fnName: 'isNaN', ruleName: 'is-nan', alternative: 'Number.isNaN()' }
+].forEach(({ fnName, ruleName, alternative }) => {
+  ruleTester.run(`Import lodash.${fnName.toLowerCase()}`, rules[ruleName || kebabCase(fnName)], {
+    valid: [],
+    invalid: [{
+      code: `import ${fnName} from 'lodash/${fnName}';`,
+      errors: [`Import from 'lodash/${fnName}' detected. Consider using the native ${alternative}`]
+    }, {
+      code: `import ${fnName} from 'lodash.${fnName.toLowerCase()}';`,
+      errors: [`Import from 'lodash.${fnName.toLowerCase()}' detected. Consider using the native ${alternative}`]
+   }, {
+      code: `import { ${fnName} as x } from 'lodash';`,
+      errors: [`Import { ${fnName} } from 'lodash' detected. Consider using the native ${alternative}`]
+    }, {
+      code: `const { ${fnName}: x } = require('lodash');`,
+      errors: [`{ ${fnName} } = require('lodash') detected. Consider using the native ${alternative}`]
+    }, {
+      code: `({ ${fnName}: x } = require('lodash'));`,
+      errors: [`{ ${fnName} } = require('lodash') detected. Consider using the native ${alternative}`]
+    }, {
+      code: `require('lodash/${fnName}');`,
+      errors: [`require('lodash/${fnName}') detected. Consider using the native ${alternative}`]
+    }, {
+      code: `require('lodash.${fnName.toLowerCase()}');`,
+      errors: [`require('lodash.${fnName.toLowerCase()}') detected. Consider using the native ${alternative}`]
+    }]
+  });
 });
 
 ruleTester.run('underscore.forEach', rules['for-each'], {
@@ -57,15 +73,6 @@ ruleTester.run('underscore.forEach', rules['for-each'], {
   invalid: [{
     code: 'underscore.forEach()',
     errors: ['Consider using the native Array.prototype.forEach()']
-  }, {
-    code: "import forEach from 'lodash/forEach';",
-    errors: ["Import from 'lodash/forEach' detected. Consider using the native Array.prototype.forEach()"]
-  }, {
-    code: "import forEach from 'lodash.foreach';",
-    errors: ["Import from 'lodash.foreach' detected. Consider using the native Array.prototype.forEach()"]
-  }, {
-    code: "import { forEach } from 'lodash';",
-    errors: ["Import { forEach } from 'lodash' detected. Consider using the native Array.prototype.forEach()"]
   }]
 });
 
@@ -76,15 +83,6 @@ ruleTester.run('underscore.isNaN', rules['is-nan'], {
   invalid: [{
     code: 'underscore.isNaN(NaN)',
     errors: ['Consider using the native Number.isNaN()']
-  }, {
-    code: "import isNaN from 'lodash/isNaN';",
-    errors: ["Import from 'lodash/isNaN' detected. Consider using the native Number.isNaN()"]
-  }, {
-    code: "import isNaN from 'lodash.isnan';",
-    errors: ["Import from 'lodash.isnan' detected. Consider using the native Number.isNaN()"]
-  }, {
-    code: "import { isNaN } from 'lodash';",
-    errors: ["Import { isNaN } from 'lodash' detected. Consider using the native Number.isNaN()"]
   }]
 });
 


### PR DESCRIPTION
Adds support for the following examples:

```js
const { indexOf } = require('lodash');
const { indexOf: x } = require('lodash');
({ indexOf } = require('lodash'));
({ indexOf: x } = require('lodash'));
const indexOf = require('lodash.indexof');
const indexOf = require('lodash/indexOf');
```

Also fixes a small issue introduced at https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore/pull/195 with the `import` detection:
```js
import { indexOf as x } from 'lodash'; // would not be detected
```