### PR TITLE
Avoid ignoring false-like values ('', 0, false, ...) for _.pick

### DIFF
--- a/README.md
+++ b/README.md
@@ -2031,7 +2031,7 @@ Creates an object composed of the object properties predicate returns truthy for
   // Native
   function pick(object, keys) {
     return keys.reduce((obj, key) => {
-       if (object[key]) {
+       if (object && object.hasOwnProperty(key)) {
           obj[key] = object[key];
        }
        return obj;


### PR DESCRIPTION
Choosing a side between `key in object` and `object.hasOwnProperty` was hard, so I picked the most explicit one :)