### PR TITLE
(chore)remove rule count, as it often caused merge conflicts

### DIFF
--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -4,8 +4,6 @@ const assert = require('assert');
 const rules = require('../../../lib/rules/all');
 const allRules = require('../../../lib/rules/rules');
 
-assert.equal(Object.keys(allRules).length, 57, 'Don\'t miss a rule 😄');
-
 const ruleTester = new RuleTester({
   parserOptions: { ecmaVersion: 2018, sourceType: "module" }
 });


### PR DESCRIPTION
Removed this. It sometimes caused merge conflicts which caused extra unnecessary rebase burden.