### PR TITLE
Fixing error for OOP isUndefined.

### DIFF
--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -25,7 +25,7 @@ for (const rule in rules) {
       return {
         CallExpression(node) {
           const callee = node.callee;
-          const objectName = callee.name || (callee.object && callee.object.name);
+          const objectName = callee.name || (callee.object && callee.object.name) || (callee.object.callee && callee.object.callee.name);
 
           if (objectName === 'require' && node.arguments.length === 1) {
             const requiredModuleName = node.arguments[0].value;

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -605,4 +605,31 @@ describe('code snippet example', () => {
       )
     })
   })
+
+  describe('isUndefined', () => {
+    const definedVariable = 1; //defined variable (will return false)
+    let undefinedVariable; //undefined variable (will return true)
+    
+    it('_.isUndefined(definedVariable)', () => {
+      assert.equal(_.isUndefined(definedVariable),
+        (definedVariable === undefined))
+    });
+
+    it('_(definedVariable).isUndefined()', () => {
+      assert.equal(_(definedVariable).isUndefined(),
+        (definedVariable === undefined))
+    });
+
+    it('_.isUndefined(undefinedVariable)', () => {
+      assert.equal(_.isUndefined(undefinedVariable),
+        (undefinedVariable === undefined))
+    });
+
+    it('_(undefinedVariable).isUndefined()', () => {
+      assert.equal(_(undefinedVariable).isUndefined(),
+        (undefinedVariable === undefined))
+    });
+
+  });
+
 })


### PR DESCRIPTION
I believed I was able to fix it. While I was doing console.log's I realized that the callee objects for the two different lines (_(myVar).isUndefined() v.s. _.isUndefined(myVar)) didn't match. The former had a structure such that:

callee.object.callee.name = '_'

rather than,
callee.object.name = '_'

This means that in certain odd cases, you'll have to go one level deeper into the callee object to find the name you are looking for. I've changed the assigning of objectName accordingly.

Fixed #208 