### PR TITLE
Fixing TypeError For Nested Function Evaluations and Adding New Tests

### DIFF
--- a/lib/rules/all.js
+++ b/lib/rules/all.js
@@ -25,7 +25,7 @@ for (const rule in rules) {
       return {
         CallExpression(node) {
           const callee = node.callee;
-          const objectName = callee.name || (callee.object && callee.object.name) || (callee.object.callee && callee.object.callee.name);
+          const objectName = callee.name || (callee.object && callee.object.name) || (callee.object && callee.object.callee && callee.object.callee.name);
 
           if (objectName === 'require' && node.arguments.length === 1) {
             const requiredModuleName = node.arguments[0].value;

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -128,16 +128,15 @@ ruleTester.run('_.isUndefined', rules['is-undefined'], {
 /*This is to make sure that You-Dont-Need-Lodash can handle the 
 evaluation of nested functions that had caused an error noted in the comments of
 Pull Request #219*/
-for (let rule in rules) {
-  ruleTester.run(rule, rules[rule], {
-    valid: [
-      `function myNestedFunction(firstInput) {
-        return (secondInput) => {
-          return firstInput + secondInput
-        }
+ruleTester.run('Nested functions', rules['is-undefined'], {
+  valid: [
+    `function myNestedFunction(firstInput) {
+      return (secondInput) => {
+        return firstInput + secondInput
       }
-      myNestedFunction(2)(2)`
-    ],
-    invalid: []
-  });
-}
+    }
+    myNestedFunction(2)(2)`
+  ],
+  invalid: []
+});
+

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -110,3 +110,34 @@ ruleTester.run('_', rules.concat, {
   ],
   invalid: []
 });
+
+ruleTester.run('_.isUndefined', rules['is-undefined'], {
+  valid: [
+    '2 === undefined'
+  ],
+  invalid: [{
+    code: '_.isUndefined(2)',
+    errors: ['Consider using the native value === undefined']
+  },{
+    code: '_(2).isUndefined()',
+    errors: ['Consider using the native value === undefined']
+
+  }]
+});
+
+/*This is to make sure that You-Dont-Need-Lodash can handle the 
+evaluation of nested functions that had caused an error noted in the comments of
+Pull Request #219*/
+for (let rule in rules) {
+  ruleTester.run(rule, rules[rule], {
+    valid: [
+      `function myNestedFunction(firstInput) {
+        return (secondInput) => {
+          return firstInput + secondInput
+        }
+      }
+      myNestedFunction(2)(2)`
+    ],
+    invalid: []
+  });
+}


### PR DESCRIPTION
The changes made to line 28 of ./lib/rules/all.js in Pull Request #219 resulted in a TypeError when trying to lint cases where you have the evaluation of nested functions, i.e.

`myNestedFunction(2)(2)`

where myNestedFunction(2) had returned a function, which you then evaluate with an argument of 2. This was due to a hole in the logic of the new statement which is fixed in this new Pull Request.

`const objectName = callee.name || (callee.object && callee.object.name) || (callee.object.callee && callee.object.callee.name);`

is now

`const objectName = callee.name || (callee.object && callee.object.name) || (callee.object && callee.object.callee && callee.object.callee.name);`

And that is because in the first version, you have the first two statements evaluate as false, and then it goes to the third where it tries to look for the callee of object of callee, which does not exist in this case.

I have included two sets of tests for these changes in ./tests/lib/rules/all.js where I:

1. Make sure that the rule successfully handles both versions of writing _.isUndefined (as mentioned in Issue #208 
2. Make sure that all rules in You-Dont-Need-Lodash-Underscore can handle the case of nested functions.

Currently, running Mocha on the ./tests/lib/rules/all.js results in all tests passing.

Fixes Issue Mentioned in Pull Request #219 and adds tests to further verify fix for Issue #208 