### PR TITLE
Adding rules and tests for _.flatten()

### DIFF
--- a/lib/rules/rules.json
+++ b/lib/rules/rules.json
@@ -262,5 +262,9 @@
         "compatible": true,
         "alternative": "{a, b, c, ...notOmittedValues}",
         "ES6": true
+    },
+    "flatten": {
+    	"compatible": true,
+    	"alternative": "Array.prototype.reduce((a,b) => a.concat(b), [])"
     }
 }

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -140,3 +140,18 @@ ruleTester.run('Nested functions', rules['is-undefined'], {
   invalid: []
 });
 
+/*Test for new flatten rule*/
+ruleTester.run('_.flatten', rules['flatten'], {
+  valid: [
+    `[1,2,[3,4]].reduce((a,b) => a.concat(b), [])`,
+    `[1,2,[3,4]].flat()`,
+    `[1,2,[3,4]].flatMap(a => a)`
+  ],
+  invalid: [{
+    code: `_.flatten([1,2,[3,4]])`,
+    errors: [`Consider using the native Array.prototype.reduce((a,b) => a.concat(b), [])`]
+  },{
+    code: `_([1,2,[3,4]]).flatten()`,
+    errors: [`Consider using the native Array.prototype.reduce((a,b) => a.concat(b), [])`]
+  }]
+});

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -632,4 +632,20 @@ describe('code snippet example', () => {
 
   });
 
+  describe('flatten', () => {
+
+    it('_.flatten(twoLayerArray)', () => {
+      const testArray = [1,2[3,4]];
+      assert.deepEqual(_.flatten(testArray),
+        testArray.reduce((a,b) => a.concat(b), []))
+    });
+
+    it('_.flatten(multiLayerArray)', () => {
+      const testArray = [1,2[3,4,[5,6,[7,8]]]];
+      assert.deepEqual(_.flatten(testArray),
+        testArray.reduce((a,b) => a.concat(b), []))
+    });
+
+  });
+
 })


### PR DESCRIPTION
Added rules for _.flatten() in lib/rules/rules.json, using the .reduce() method as the suggestion given that it is the most widely compatible.

I've also included linter tests in tests/lib/rules/all.js for _.flatten() along with .reduce(), .flat, and .flatMap() as the valid alternatives.

Finally, I've included unit tests in tests/unit/all.js to verify that .reduce() and _.flatten() produce the same results for a two-layer and multi-layer array. 

Currently passes all linter and unit tests using Mocha.

This was done in response to Issue #145.