### PR TITLE
Adding Object.entries().forEach() as alternative for _.each() and _.forEach()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,16 +1001,30 @@ Iterates over a list of elements, yielding each in turn to an iteratee function.
 
   ```js
   // Underscore/Lodash
+  //For arrays
   _.each([1, 2, 3], function (value, index) {
     console.log(value)
   })
   // output: 1 2 3
 
+  //For objects
+  _.each({'one':1, 'two':2, 'three':3}, function(value) {
+    console.log(value)
+  })
+  // output: 1 2 3
+
   // Native
+  //For arrays
   [1, 2, 3].forEach(function (value, index) {
     console.log(value)
   })
   // output: 1 2 3
+
+  //For objects
+  Object.entries({'one':1, 'two':2, 'three':3}).forEach(function([key,value],index) {
+    console.log(value)
+  })
+  //output: 1 2 3
   ```
 
 #### Browser Support for `Array.prototype.forEach()`

--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,12 @@ Iterates over a list of elements, yielding each in turn to an iteratee function.
 :-: | :-: | :-: | :-: | :-: | :-: |
   ✔  | ✔ | 1.5 ✔ |  9.0 ✔  |  ✔  |  ✔  |
 
+#### Browser Support for `Object.entries().forEach()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  54 ✔  | 14 ✔ | 47 ✔ |  ✖  |  41 ✔  |  10.1✔  |
+
 **[⬆ back to top](#quick-links)**
 
 ### _.every

--- a/lib/rules/rules.json
+++ b/lib/rules/rules.json
@@ -62,11 +62,11 @@
 
     "each": {
         "compatible": false,
-        "alternative": "Array.prototype.forEach()"
+        "alternative": "Array.prototype.forEach() or Object.entries().forEach()"
     },
     "forEach": {
         "compatible": false,
-        "alternative": "Array.prototype.forEach()"
+        "alternative": "Array.prototype.forEach() or Object.entries().forEach()"
     },
     "every": {
         "compatible": false,

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -58,11 +58,12 @@ ruleTester.run(`Import lodash.isnan`, rules['is-nan'], {
 
 ruleTester.run('underscore.forEach', rules['for-each'], {
   valid: [
-    '[0, 1].forEach()'
+    '[0, 1].forEach()',
+    "Object.entries({'one':1,'two':2}).forEach()"
   ],
   invalid: [{
     code: 'underscore.forEach()',
-    errors: ['Consider using the native Array.prototype.forEach()']
+    errors: ['Consider using the native Array.prototype.forEach() or Object.entries().forEach()']
   }]
 });
 
@@ -155,3 +156,5 @@ ruleTester.run('_.flatten', rules['flatten'], {
     errors: [`Consider using the native Array.prototype.reduce((a,b) => a.concat(b), [])`]
   }]
 });
+
+

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -648,4 +648,46 @@ describe('code snippet example', () => {
 
   });
 
+  describe('forEach', () => {
+    it('_.forEach(array)', () => {
+      const testArray = [1,2,3,4];
+      
+      let lodashOutput = []
+      let nativeOutput = []
+
+      _.forEach(testArray, element => {
+        lodashOutput.push(element);
+      });
+      testArray.forEach(element => {
+        nativeOutput.push(element);
+      });
+
+      assert.deepEqual(lodashOutput,nativeOutput);
+
+    });
+
+    it('_.forEach(object)', () => {
+      const testObject = {
+        'one':1,
+        'two':2,
+        'three':3,
+        'four':4,
+      }
+
+      let lodashOutput = []
+      let nativeOutput = []
+
+      _.forEach(testObject, value => {
+        lodashOutput.push(value);
+      });
+
+      Object.entries(testObject).forEach(([key,value]) => {
+        nativeOutput.push(value);
+      });
+
+      assert.deepEqual(lodashOutput,nativeOutput);
+
+    });
+  });
+
 })


### PR DESCRIPTION
As suggested in #125, I have included Object.entries.forEach() as a secondary suggestion in the rules. This is important given that, as it is, object inputs with _.forEach() will result in getting a suggestion from Eslint that is incorrect (as mentioned in #229).

I have included the object alternative in the suggestion statement in the rules, and I have created rule and unit tests for _.forEach for both array and object versions. Currently, all tests pass.

Finally, I have updated the README file to include the secondary suggestion and have included the compatibility for Object.entries().forEach() based on the compatibility listed for Object.entries() on MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries).

A more rigorous solution would be to modify the plugin to make suggests based on the type of the function input, but this is my proposed solution for the time being.

This fixes Issues #125 and #229.