### PR TITLE
Updating README file to be consistent with #231

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,8 +991,8 @@ Returns an array where matching items are filtered.
 
 ## Collection*
 
-*:heavy_exclamation_mark:<b>Important:</b> Note that the native equivalents are array methods,
-and will not work with objects. If this functionality is needed,
+*:heavy_exclamation_mark:<b>Important:</b> Note that most native equivalents are array methods,
+and will not work with objects. If this functionality is needed and no object method is provided,
 then Lodash/Underscore is the better option.*
 
 ### _.each

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ suggest that you take extra precautions [e.g. consider using the native Object.k
 
 **[Collection*](#collection*)**
 
-*:heavy_exclamation_mark:<b>Important:</b> Note that the native equivalents are array methods,
-and will not work with objects. If this functionality is needed,
+*:heavy_exclamation_mark:<b>Important:</b> Note that most native equivalents are array methods,
+and will not work with objects. If this functionality is needed and no object method is provided,
 then Lodash/Underscore is the better option.*
 
 1. [_.each](#_each)


### PR DESCRIPTION
As I have added an object alternative to _.each() in #231, the warning about the Collections methods in the table of contents and the Collections section being array-only methods was no longer accurate and thus could be confusing to users reading through the documentation.

I have changed those two warnings to read that they are "mostly" all array methods, and that if no object methods are listed, then you still may need Lodash/Underscore.

I apologize for not updating this in the mentioned PR.