### PR TITLE
Fix debounce function bug when immediate is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -1656,12 +1656,12 @@ Create a new function that calls _func_ with _thisArg_ and _args_.
 	var timeout;
 	return function() {
 		var context = this, args = arguments;
+		if (immediate && !timeout) func.apply(context, args);
 		clearTimeout(timeout);
 		timeout = setTimeout(function() {
 			timeout = null;
 			if (!immediate) func.apply(context, args);
 		}, wait);
-		if (immediate && !timeout) func.apply(context, args);
 	};
 }
 


### PR DESCRIPTION
When immediate is true, the debounced func will never called.