### PR TITLE
New faster _.extend alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -2079,11 +2079,17 @@ The method is used to copy the values of all enumerable own and inherited proper
 
   //Or using a function
   const extend = (target, ...sources) => {
-    let source = [];
-    sources.forEach(src => {
-      source = source.concat([src, Object.getPrototypeOf(src)])
-    })
-    return Object.assign(target, ...source)
+   const length = sources.length;
+
+    if (length < 1 || target == null) return target;
+    for (let i = 0; i < length; i++) {
+      const source = sources[i];
+
+      for (const key in source) {
+        target[key] = source[key];
+      }
+    }
+    return target;
   };
   console.log(extend({}, new Foo, new Bar));
   // output: { 'c': 3, 'd': 4, 'e': 5, 'f': 6 }

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -148,12 +148,19 @@ describe('code snippet example', () => {
     }
     Foo.prototype.d = 4;
     Bar.prototype.f = 6;
+
     const extend = (target, ...sources) => {
-      let source = [];
-      sources.forEach(src => {
-        source = source.concat([src, Object.getPrototypeOf(src)])
-      })
-      return Object.assign(target, ...source)
+      const length = sources.length;
+
+      if (length < 1 || target == null) return target;
+      for (let i = 0; i < length; i++) {
+        const source = sources[i];
+
+        for (const key in source) {
+          target[key] = source[key];
+        }
+      }
+      return target;
     };
 
     it("_.extend({}, new Foo, new Bar);", () => {


### PR DESCRIPTION
During the process of dropping lodash for [hexo](https://github.com/hexojs/hexo) project, we have faced serious obstacles when replacing `lodash.assignIn` with native javascript. We have tried the example function from the README but soon run into serious performance regression. After some investigations, it turns out that the `Object.getPrototypeOf()` is the culprit.

After trying `Object.getPrototypeOf()`, `Reflect.getPrototypeOf()` even the deprecated `__proto__`, the performance regression remains. We finally drops `lodash.assignIn` (https://github.com/hexojs/hexo/pull/3969) with a pure javascript alternative without bringing in any performance regression. It proves that `for...in...` is still the fastest way to iterate over the properties of an object.