### PR TITLE
Allow get to support keys with dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2117,11 +2117,14 @@ Gets the value at path of object.
   
   // Native
   const get = (obj, path, defaultValue) => {
-    const result = String.prototype.split.call(path, /[,[\].]+?/)
-      .filter(Boolean)
-      .reduce((res, key) => (res !== null && res !== undefined) ? res[key] : res, obj);
-    return (result === undefined || result === obj) ? defaultValue : result;
-  }
+    const travel = regexp =>
+      String.prototype.split
+        .call(path, regexp)
+        .filter(Boolean)
+        .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
+    const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+    return result === undefined || result === obj ? defaultValue : result;
+  };
   
   var object = { a: [{ b: { c: 3 } }] };
   var result = get(object, 'a[0].b.c', 1); 

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -232,12 +232,21 @@ describe('code snippet example', () => {
   })
   describe('get', () => {
     const get = (obj, path, defaultValue) => {
-      const result = String.prototype.split.call(path, /[,[\].]+?/)
-        .filter(Boolean)
-        .reduce((res, key) => (res !== null && res !== undefined) ? res[key] : res, obj);
-      return (result === undefined || result === obj) ? defaultValue : result;
-    }
-    var obj = { aa: [{ b: { c: 0 }, 1: 0 }], dd: { ee: { ff: 2 } } };
+      const travel = regexp =>
+        String.prototype.split
+          .call(path, regexp)
+          .filter(Boolean)
+          .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
+      const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
+      return result === undefined || result === obj ? defaultValue : result;
+    };
+    var obj = {
+      aa: [{ b: { c: 0 }, 1: 0 }],
+      dd: { ee: { ff: 2 } },
+      gg: { h: 2 },
+      "gg.h": 1,
+      "kk.ll": { "mm.n": [3, 4, { "oo.p": 5 }] }
+    };
 
     it ("should handle falsey values", () => {
       var val = _.get(obj, 'aa[0].b.c', 1)
@@ -299,6 +308,18 @@ describe('code snippet example', () => {
     it ("should handle undefined obj", () => {
       var val = _.get(undefined, 'aa')
       assert.strictEqual(val, get(undefined, 'aa'))
+    })
+    it ("should handle path contains a key with dots", () => {
+      var val = _.get(obj, 'gg.h')
+      assert.strictEqual(val, get(obj, 'gg.h'))
+      assert.strictEqual(val, 1)
+    })
+    it ("should handle array path of keys with dots", () => {
+      var val = _.get(obj, ["kk.ll", "mm.n", 0, "oo.p"])
+      assert.strictEqual(
+        val,
+        get(obj, ["kk.ll", "mm.n", 0, "oo.p"])
+      );
     })
   })
   describe('split', () => {


### PR DESCRIPTION
Make get to support keys with dots. For example:
```
get({ 'a.b': 4, a: { b: 5 } }, 'a.b') // => 4
get({ 'a.a': { b: [ { 'c.c': 4 }, 2, 5 ] } }, ['a.a', 'b', 0, 'c.c']) // => 4
```

https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore/issues/242