### PR TITLE
add optional chaining for _.get in README.md and add eslint rule (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2130,8 +2130,14 @@ Gets the value at path of object.
 
   // Native (ES6 - IE not supported)
   var object = { a: [{ b: { c: 3 } }] };
-  var { a: [{ b: { c: result2 = 1 } }] } = object;
-  console.log(result2);
+  var { a: [{ b: { c: result = 1 } = {} } = {}] = [] } = object;
+  console.log(result);
+  // output: 3
+
+  // Native (ES11)
+  var object = { a: [{ b: { c: 3 } }] };
+  var result = object?.a?.[0]?.b?.c ?? 1;
+  console.log(result);
   // output: 3
   
   // Native
@@ -2156,6 +2162,18 @@ Gets the value at path of object.
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |
   49.0 ✔  | 14.0 ✔ |  41.0 ✔ |  ✖  |  41.0 ✔ |  8.0 ✔ |
+
+#### Browser Support for optional chaining `?.`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  80.0 ✔  | 80.0 ✔ |  74.0 ✔ |  ✖  |  67.0 ✔ |  13.1 ✔ |
+
+#### Browser Support for nullish coalescing operator `??`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  80.0 ✔  | 80.0 ✔ |  72.0 ✔ |  ✖  |  ✖ |  13.1 ✔ |
 
   **[⬆ back to top](#quick-links)**
 

--- a/lib/rules/rules.json
+++ b/lib/rules/rules.json
@@ -214,6 +214,11 @@
         "alternative": "Object.entries()",
         "ES6": true
     },
+    "get": {
+        "compatible": false,
+        "alternative": "optional chaining to get nested values and nullish coalescing operator for fallback values",
+        "ES11": true
+    },
     "split": {
         "compatible": true,
         "alternative": "String.prototype.split()"


### PR DESCRIPTION
What I've done:
- In the README.md I replaced the ES6 object destructing example with ES11 [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)
- In the rules.json I added a new rule for _.get suggesting to use optional chaining and nullish coalescing operator instead
