### PR TITLE
Correct the description of _.isString

### DIFF
--- a/README.md
+++ b/README.md
@@ -2437,7 +2437,7 @@ Checks if string ends with the given target string.
 
 ### _.isString
 :heavy_exclamation_mark:`Not in Underscore.js`
-Checks if string ends with the given target string.
+Checks if value is classified as a String primitive or object.
 
   ```js
   // Lodash


### PR DESCRIPTION
The previous description was copy-pasted from `_.endsWith`. This updated description comes from https://lodash.com/docs/4.17.15#isString.