### PR TITLE
chore: enable travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
+  - 14
 
 script:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ node_js:
   - 14
 
 script:
-  - npm run coveralls
   - npm run test:unit
+  - npm run test
+  - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
+
 node_js:
   - 6
   - 8
   - 10
   - 12
-after_success:
+
+script:
   - npm run coveralls
   - npm run test:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - 14
 
 script:
-  - npm run test:unit
-  - npm run test
-  - npm run coveralls
+  - yarn test
+  - yarn test:unit
+
+after_success:
+  - yarn coveralls

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -590,7 +590,7 @@ describe('code snippet example', () => {
       assert.deepStrictEqual(clamp(-10, -5, 5), -5);
     });
     it('clamp(10, -5, 5) returns upper bound if number is greater than it', () => {
-      assert.deepStrictEqual(clamp(10, -5, 5), 10);
+      assert.deepStrictEqual(clamp(10, -5, 5), 5);
     });
     it('clamp(10, -5) treats second parameter as upper bound', () => {
       assert.deepStrictEqual(clamp(10, -5), -5);


### PR DESCRIPTION
- Unit tests errors are no longer ignored in Travis builds
- Removes EOL Node.js versions and adds 14 to the matrix