### PR TITLE
feat(gh-page): zero effort gh-page from readme with docsify

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+[remoteMarkdownUrl](https://raw.githubusercontent.com/you-dont-need/You-Dont-Need-Lodash-Underscore/master/README.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>You don’t (may not) need Lodash/Underscore</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: 'You don\'t need Lodash',
+      nameLink: '/',
+      repo: 'https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore',
+      autoHeader: true,
+      maxLevel: 3,
+      markdown: {
+        smartypants: true
+      },
+
+      remoteMarkdown: {
+        tag: 'remoteMarkdownUrl',
+      },
+    }
+  </script>
+  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="//unpkg.com/docsify-remote-markdown/dist/docsify-remote-markdown.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-js-extras.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-js-templates.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-jsdoc.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Hi there

Actually I never used your eslint plugin.  
Instead, I came looking up things in your repos readme allot, since that rendered as a great quick documentation for me.

The only flaw so far was that the readme isn't all that great to navigate.

I reckon with [Docsify](https://github.com/docsifyjs/docsify/) the exact same Readme can be rendered into a nicer to use webpage with next to no effort at all for you guys
It doesn't even require a build.

All you'd need to change would be enabling github pages for the docs directory of your project and https://you-dont-need.github.io/You-Dont-Need-Lodash-Underscore would be ready.

See: https://casaper.github.io/You-Dont-Need-Lodash-Underscore/#/