### PR TITLE
chore: fix main entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "Patrick McElhaney <pmcelhaney@gmail.com> (http://patrickmcelhaney.com)",
     "Steve Mao <maochenyan@gmail.com> (https://github.com/stevemao)"
   ],
-  "main": "lib/index.js",
+  "main": "index.js",
   "scripts": {
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "test": "istanbul cover tests",


### PR DESCRIPTION
`package.json` specifies a `main` entry of `lib/index.js`, which doesn’t exist. A bit untidy, and Yarn Berry spits out tedious warnings about invalid entries.