### PR TITLE
Remove unnecessary falsey checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1860,7 +1860,7 @@ _.isFunction(/abc/);
 
 // Native
 function isFunction(func) {
-  return (typeof func === "function");
+  return typeof func === "function";
 }
 
 isFunction(setTimeout);


### PR DESCRIPTION
No reason to check if `func` is falsey because if it is then it couldn't be `typeof function`