### PR TITLE
Fix: Header order -> section order

### DIFF
--- a/README.md
+++ b/README.md
@@ -3243,7 +3243,8 @@ Checks if n is between start and up to, but not including, end. If end is not sp
 
 **[⬆ back to top](#quick-links)**
 
-  ### _.random
+### _.random
+
 Produces a random number between the inclusive lower and upper bounds. If only one argument is provided a number between 0 and the given number is returned. If floating is true, or either lower or upper are floats, a floating-point number is returned instead of an integer.
 
   ```js
@@ -3299,7 +3300,7 @@ Produces a random number between the inclusive lower and upper bounds. If only o
 
   ```
 
-  #### Browser Support for `Math.random()`
+#### Browser Support for `Math.random()`
 
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |

--- a/README.md
+++ b/README.md
@@ -3116,14 +3116,6 @@ Uppercases the first letter of a given string
 
 **[⬆ back to top](#quick-links)**
 
-## Reference
-
-* [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
-* [Underscore.js](http://underscorejs.org)
-* [Lodash.js](https://lodash.com/docs)
-
-**[⬆ back to top](#quick-links)**
-
 ## Util
 
 ### _.times
@@ -3308,7 +3300,13 @@ Produces a random number between the inclusive lower and upper bounds. If only o
 
 **[⬆ back to top](#quick-links)**
 
+## Reference
 
+* [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
+* [Underscore.js](http://underscorejs.org)
+* [Lodash.js](https://lodash.com/docs)
+
+**[⬆ back to top](#quick-links)**
 
 ## Inspired by:
 

--- a/README.md
+++ b/README.md
@@ -1799,6 +1799,39 @@ Produces a duplicate-free version of the array, using === to test object equalit
 
 **[⬆ back to top](#quick-links)**
 
+### _.uniqWith
+
+similar to _.uniq except that it accepts comparator which is invoked to compare elements of array. The order of result values is determined by the order they occur in the array.
+
+  ```js
+  // Lodash
+  const objects = [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }, { 'x': 1, 'y': 2 }];
+  const result = _.uniqWith(objects, _.isEqual);
+  console.log(result);
+  // output: [{ x: 1, y: 2 }, { x: 2, y: 1 }]
+
+  // Native
+  const uniqWith = (arr, fn) => arr.filter((element, index) => arr.findIndex((step) => fn(element, step)) === index);
+
+  const array = [1, 2, 2, 3, 4, 5, 2];
+  const result = uniqWith(array, (a, b) => a === b);
+  console.log(result);
+  // output: [1, 2, 3, 4, 5]
+
+  const objects = [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }, { 'x': 1, 'y': 2 }];
+  const result = uniqWith(objects, (a, b) => JSON.stringify(a) === JSON.stringify(b));
+  console.log(result);
+  // output: [{ x: 1, y: 2 }, { x: 2, y: 1 }]
+  ```
+
+#### Browser Support for `Array.prototype.filter()` and `Array.prototype.findIndex()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+ 45.0  ✔  | 12.0 ✔ | 25.0 ✔ |  ✖  |  32.0 ✔  |  8.0 ✔  |
+
+**[⬆ back to top](#quick-links)**
+
 ## Function
 
 ### _.after
@@ -3088,39 +3121,6 @@ Uppercases the first letter of a given string
 * [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
 * [Underscore.js](http://underscorejs.org)
 * [Lodash.js](https://lodash.com/docs)
-
-**[⬆ back to top](#quick-links)**
-
-### _.uniqWith
-
-similar to _.uniq except that it accepts comparator which is invoked to compare elements of array. The order of result values is determined by the order they occur in the array.
-
-  ```js
-  // Lodash
-  const objects = [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }, { 'x': 1, 'y': 2 }];
-  const result = _.uniqWith(objects, _.isEqual);
-  console.log(result);
-  // output: [{ x: 1, y: 2 }, { x: 2, y: 1 }]
-
-  // Native
-  const uniqWith = (arr, fn) => arr.filter((element, index) => arr.findIndex((step) => fn(element, step)) === index);
-
-  const array = [1, 2, 2, 3, 4, 5, 2];
-  const result = uniqWith(array, (a, b) => a === b);
-  console.log(result);
-  // output: [1, 2, 3, 4, 5]
-
-  const objects = [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }, { 'x': 1, 'y': 2 }];
-  const result = uniqWith(objects, (a, b) => JSON.stringify(a) === JSON.stringify(b));
-  console.log(result);
-  // output: [{ x: 1, y: 2 }, { x: 2, y: 1 }]
-  ```
-
-### Browser Support for `Array.prototype.filter()` and `Array.prototype.findIndex()`
-
-![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
-:-: | :-: | :-: | :-: | :-: | :-: |
- 45.0  ✔  | 12.0 ✔ | 25.0 ✔ |  ✖  |  32.0 ✔  |  8.0 ✔  |
 
 **[⬆ back to top](#quick-links)**
 


### PR DESCRIPTION
Fixed:

1. _.uniqWith not within the `## Collection*` header section
1. _.uniqWith's `### Browser Support for` -> `#### Browser Support for` so it is arranged within not adjacent of _.uniqWith
1. `### _.random` header indentation
1. `## Reference` at the end, because it seems more appropriate there

This allows to have the grouping with GitHubs header navigator:

<img width="367" alt="image" src="https://user-images.githubusercontent.com/5822656/152530973-426e8aca-3444-4328-8d78-dd0748fc1901.png">

and with the GitHub pages version of this readme, would then also list uniqWith in the collections section:

http://you-dont-need.github.io/You-Dont-Need-Lodash-Underscore/#/?id=_uniq

