### PR TITLE
Fix: errorneous description for _.isNull

### DIFF
--- a/README.md
+++ b/README.md
@@ -2253,7 +2253,7 @@ console.log(undefined == null)
 
 ### _.isNull
 
-Checks if value is null or undefined.
+Checks if value is null.
 
 ```js
 // Underscore/Lodash


### PR DESCRIPTION
Fix description that claims `_.isNull` to check for undefined. 

Calling `_.isNull(undefined)` returns `false`. The observed behaviour can also be verified from source https://github.com/lodash/lodash/blob/2f79053d7bc7c9c9561a30dda202b3dcd2b72b90/isNull.js#L17