### PR TITLE
Fix _first test

### DIFF
--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -108,10 +108,10 @@ ruleTester.run('_.first', rules['first'], {
   ],
   invalid: [{
       code: '_.first([0, 1, 3])',
-      errors: ['Consider using the native Array.prototype.slice()']
+      errors: ['Consider using the native Array.prototype.slice() or arr[0]']
   }, {
     code: '_.first([0, 1, 3], 2)',
-    errors: ['Consider using the native Array.prototype.slice()']
+    errors: ['Consider using the native Array.prototype.slice() or arr[0]']
   }]
 });
 


### PR DESCRIPTION
Looks like `arr[0]` was added like suggested in #312 but the test was not updated causing `yarn test` failure.