### PR TITLE
head, first & last rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,13 @@ Returns the first element of an array. Passing n will return the first n element
 
   [1, 2, 3, 4, 5].slice(0, 2);
   // => [1, 2]
+
+  // Native with ES13
+  [1, 2, 3, 4, 5].at(0)
+  // => 1
+  //or
+  [].at(0)
+  // => undefined
   ```
 
 #### Browser Support for `Array.prototype.slice()`
@@ -529,6 +536,12 @@ Returns the first element of an array. Passing n will return the first n element
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |
   1.0 ✔  |  ✔  |  1.0 ✔  |  ✔  |  ✔  | ✔  |
+
+#### Browser Support for `Array.prototype.at()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  92 ✔  |  92 ✔  | 90 ✔  | ✖  | 78 ✔  | 15.4 ✔  |
 
 **[⬆ back to top](#quick-links)**
 
@@ -693,6 +706,10 @@ Gets the first element or all but the first element.
   // output: 1
   console.log(tail)
   // output [2, 3]
+
+  // Native replacement for _.head in ES13
+  array.at(0)
+  // output: 1
   ```
 
 #### Browser Support for Spread in array literals
@@ -700,6 +717,12 @@ Gets the first element or all but the first element.
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |
   46.0 ✔  | 12.0 ✔ |  16.0 ✔ |  ✖ |  37.0 ✔ | 8.0 ✔  |
+
+#### Browser Support for `Array.prototype.at()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  92 ✔  |  92 ✔  | 90 ✔  | ✖  | 78 ✔  | 15.4 ✔  |
 
 **[⬆ back to top](#quick-links)**
 

--- a/lib/rules/rules.json
+++ b/lib/rules/rules.json
@@ -21,7 +21,8 @@
     },
     "last": {
         "compatible": true,
-        "alternative": "Array.prototype.slice()"
+        "alternative": "Array.prototype.at(-1) or Array.prototype.slice()",
+        "ES13": true
     },
     "lastIndexOf": {
         "compatible": true,
@@ -48,7 +49,8 @@
     },
     "first": {
         "compatible": true,
-        "alternative": "Array.prototype.slice() or arr[0]"
+        "alternative": "Array.prototype.at(0) or Array.prototype.slice()",
+        "ES13": true
     },
     "findIndex": {
         "compatible": false,
@@ -312,5 +314,10 @@
     "isArrayBuffer": {
         "compatible": false,
         "alternative": "value instanceof ArrayBuffer"
+    },
+    "head": {
+        "compatible": true,
+        "alternative": "Array.prototype.at(0)",
+        "ES13": true
     }
 }

--- a/tests/lib/rules/all.js
+++ b/tests/lib/rules/all.js
@@ -104,28 +104,30 @@ ruleTester.run('underscore.isNaN', rules['is-nan'], {
 ruleTester.run('_.first', rules['first'], {
   valid: [
     '[0, 1, 3][0]',
+    '[0, 1, 3].at(0)',
     '[0, 1, 3].slice(0, 2)'
   ],
   invalid: [{
       code: '_.first([0, 1, 3])',
-      errors: ['Consider using the native Array.prototype.slice() or arr[0]']
+      errors: ['Consider using the native Array.prototype.at(0) or Array.prototype.slice()']
   }, {
     code: '_.first([0, 1, 3], 2)',
-    errors: ['Consider using the native Array.prototype.slice() or arr[0]']
+    errors: ['Consider using the native Array.prototype.at(0) or Array.prototype.slice()']
   }]
 });
 
 ruleTester.run('_.last', rules['last'], {
   valid: [
     'var numbers = [0, 1, 3]; numbers[numbers.length - 1]',
+    '[0, 1, 3].at(-1)',
     '[0, 1, 3].slice(-2)'
   ],
   invalid: [{
       code: '_.last([0, 1, 3])',
-      errors: ['Consider using the native Array.prototype.slice()']
+      errors: ['Consider using the native Array.prototype.at(-1) or Array.prototype.slice()']
   }, {
     code: '_.last([0, 1, 3], 2)',
-    errors: ['Consider using the native Array.prototype.slice()']
+    errors: ['Consider using the native Array.prototype.at(-1) or Array.prototype.slice()']
   }]
 });
 
@@ -222,6 +224,16 @@ ruleTester.run('_.endsWith', rules['ends-with'], {
     code: '_.endsWith("abc", "b", 1)',
     errors: ['Consider using the native String.prototype.endsWith()']
 
+  }]
+});
+
+ruleTester.run('_.head', rules['head'], {
+  valid: [
+    '[0, 1, 3].at(0)',
+  ],
+  invalid: [{
+      code: '_.head([0, 1, 3])',
+      errors: ['Consider using the native Array.prototype.at(0)']
   }]
 });
 

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -977,5 +977,24 @@ describe('code snippet example', () => {
     it('_.last([1,2,3,4,5])', () => {
       assert.deepEqual(_.last([1,2,3,4,5]), [1,2,3,4,5].at(-1));
     });
+    it('_.last([])', () => {
+      assert.deepEqual(_.last([]), [].at(-1));
+    });
   });
+  describe('first', () => {
+    it('_.first([1,2,3,4,5])', () => {
+      assert.deepEqual(_.first([1,2,3,4,5]), [1,2,3,4,5].at(0));
+    });
+    it('_.first([])', () => {
+      assert.deepEqual(_.first([]), [].at(0));
+    });
+  })
+  describe('head', () => {
+    it('_.head([1,2,3,4,5])', () => {
+      assert.deepEqual(_.head([1,2,3,4,5]), [1,2,3,4,5].at(0));
+    });
+    it('_.head([])', () => {
+      assert.deepEqual(_.head([]), [].at(0));
+    });
+  })
 });


### PR DESCRIPTION
- Add new rule for .head()
- Modify existing rules for .first() & .last()

Suggest the use of Array.prototype.at() instead for ES13(I would prefer to use Ecmascript 2022, but didn't see any previous use of that convention). 