### PR TITLE
Upgrade dependabot/fetch-metadata

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR


### PR DESCRIPTION
v1.1.1 emitted warnings because of usage of Node.js v12.
