### PR TITLE
Updating support for _.groupBy() using  Object.groupBy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1323,6 +1323,11 @@ Group items by key.
   var grouped = ['one', 'two', 'three'].reduce((r, v, i, a, k = v.length) => ((r[k] || (r[k] = [])).push(v), r), {})
   console.log(grouped)
   // output: {3: ["one", "two"], 5: ["three"]}
+
+  // Native (with Object.groupBy)
+  var grouped = Object.groupBy(['one', 'two', 'three'], v => v.length)
+  console.log(grouped)
+  // output: {3: ["one", "two"], 5: ["three"]}
   ```
 
   ```js
@@ -1335,6 +1340,11 @@ Group items by key.
   var grouped = [1.3, 2.1, 2.4].reduce((r, v, i, a, k = Math.floor(v)) => ((r[k] || (r[k] = [])).push(v), r), {})
   console.log(grouped)
   // output: {1: [1.3], 2: [2.1, 2.4]}
+  
+  // Native (with Object.groupBy)
+  var grouped = Object.groupBy([1.3, 2.1, 2.4], num => Math.floor(num))
+  console.log(grouped)
+  // output: {1: [1.3], 2: [2.1, 2.4]}
   ```
 
 #### Browser Support for `Array.prototype.reduce()`
@@ -1342,6 +1352,12 @@ Group items by key.
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |
   ✔  | ✔  | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
+
+#### Browser Support for `Object.groupBy()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  117 ✔  | 117 ✔  | 119 ✔ |  ✖  |  103 ✔ |  ✖  |
 
 **[⬆ back to top](#quick-links)**
 


### PR DESCRIPTION
## Overview
Update the sample codes for `_groupBy` as `Object.groupBy()` is now natively supported.

## Notes
* Safari currently supports `Object.groupBy()` in Technical Preview (TP). However, as it is not part of an official release, it is marked as unsupported (`x`) in this PR.
* Please note that not all browsers have added support for this feature. Therefore, we need to discuss whether to include it or not.

## Links

* MDN Web Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy#browser_compatibility

* Can I use: https://caniuse.com/mdn-javascript_builtins_object_groupby