### PR TITLE
Mention Object.groupBy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1323,6 +1323,10 @@ Group items by key.
   var grouped = ['one', 'two', 'three'].reduce((r, v, i, a, k = v.length) => ((r[k] || (r[k] = [])).push(v), r), {})
   console.log(grouped)
   // output: {3: ["one", "two"], 5: ["three"]}
+
+  // Native
+  Object.groupBy(['one', 'two', 'three'], ({length}) => length)
+  // output: {3: ["one", "two"], 5: ["three"]}
   ```
 
   ```js
@@ -1335,6 +1339,10 @@ Group items by key.
   var grouped = [1.3, 2.1, 2.4].reduce((r, v, i, a, k = Math.floor(v)) => ((r[k] || (r[k] = [])).push(v), r), {})
   console.log(grouped)
   // output: {1: [1.3], 2: [2.1, 2.4]}
+
+  // Native
+  Object.groupBy([1.3, 2.1, 2.4], num => Math.floor(num))
+  // output: {1: [1.3], 2: [2.1, 2.4]}
   ```
 
 #### Browser Support for `Array.prototype.reduce()`
@@ -1342,6 +1350,12 @@ Group items by key.
 ![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
 :-: | :-: | :-: | :-: | :-: | :-: |
   ✔  | ✔  | 3.0 ✔ |  9.0 ✔  |  10.5 ✔ |  4.0 ✔ |
+
+#### Browser Support for `Object.groupBy()`
+
+![Chrome][chrome-image] | ![Edge][edge-image] | ![Firefox][firefox-image] | ![IE][ie-image] | ![Opera][opera-image] | ![Safari][safari-image]
+:-: | :-: | :-: | :-: | :-: | :-: |
+  117.0 ✔  | 117.0 ✔ | 119.0 ✔ |  ✖  |  103.0 ✔ |  16.4 ✔ |
 
 **[⬆ back to top](#quick-links)**
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy

One thing to note - MDN says Safari uses a different function - `Array.prototype.groupToMap`. Not sure if it is worth mentioning.