### PR TITLE
Fix #393 remove a destructuring assignment example on _.pick native implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2818,16 +2818,9 @@ Creates an object composed of the object properties predicate returns truthy for
   var object = { 'a': 1, 'b': '2', 'c': 3 };
 
   // Underscore/Lodash
-  var result = _.pick(object, ['a', 'c']);
+  var result = _.pick(object, ['a', 'c', 'x']);
   console.log(result)
   // output: {a: 1, c: 3}
-
-  // Native
-  const { a, c } = object;
-  const result = { a, c};
-  console.log(result);
-  // output: {a: 1, c: 3}
-  // for an array of this object --> array.map(({a, c}) => ({a, c}));
 
   // Native
   function pick(object, keys) {
@@ -2838,7 +2831,7 @@ Creates an object composed of the object properties predicate returns truthy for
        return obj;
      }, {});
   }
-  var result = pick(object, ['a', 'c']);
+  var result = pick(object, ['a', 'c', 'x']);
   console.log(result)
   // output: {a: 1, c: 3}
   ```

--- a/tests/unit/all.js
+++ b/tests/unit/all.js
@@ -62,18 +62,17 @@ describe('code snippet example', () => {
 
   it('pick', () => {
     var object = { 'a': 1, 'b': '2', 'c': 3 };
-    function pick(object, paths) {
-      const obj = {};
-      for (const path of paths) {
-        if (object[path]) {
-          obj[path] = object[path]
+    function pick(object, keys) {
+      return keys.reduce((obj, key) => {
+        if (object && object.hasOwnProperty(key)) {
+          obj[key] = object[key];
         }
-      }
-      return obj;
+        return obj;
+      }, {});
     }
     assert.deepEqual(
-      _.pick(object, ['a', 'c']),
-      pick(object, ['a', 'c'])
+      _.pick(object, ['a', 'c', 'x']),
+      pick(object, ['a', 'c', 'x'])
     )
   })
   


### PR DESCRIPTION
This PR will fix #393 .

* shows explicitly the _.pick ignores non-existent key
* modify test implementation equavalent to README.md example