### PR TITLE
Support ESLint flat config

### DIFF
--- a/configuring.md
+++ b/configuring.md
@@ -13,7 +13,9 @@ npm install --save-dev eslint
 npm install --save-dev eslint-plugin-you-dont-need-lodash-underscore
 ```
 
-### Add the plugin to your .eslintrc.js file
+### Add the plugin to your ESLint configuration
+
+#### Legacy config (.eslintrc.js)
 
 ```js
 "plugins": ["you-dont-need-lodash-underscore"],
@@ -24,6 +26,23 @@ If you already have plugins installed, just add to the array.
 ```js
 "plugins": ["react", "you-dont-need-lodash-underscore"],
 ```
+
+#### Flat config (eslint.config.js)
+
+At the top of the file, import the plugin using the appropriate style
+```js
+// ESM
+import youDontNeedLodashUnderscore from 'eslint-plugin-you-dont-need-lodash-underscore';
+
+// CommonJS
+const youDontNeedLodashUnderscore = require( 'eslint-plugin-you-dont-need-lodash-underscore' );
+```
+
+Then add it to your plugins object:
+```js
+"plugins": { 'you-dont-need-lodash-underscore': youDontNeedLodashUnderscore },
+```
+If you already have plugins installed, just add the key to the existing object.
 
 ### Now configure your plugin.
 
@@ -42,7 +61,17 @@ To save the trouble of configuring each rule individually, you can start by exte
 default configurations, and then override individual rules as desired.
 
 ```js
+// eslintrc
 "extends" : ["plugin:you-dont-need-lodash-underscore/compatible"],
+
+// flat config
+youDontNeedLodashUnderscore.flatConfigs.compatible,
+
+// flat config using defineConfig's string extends
+{
+    "plugins": { "you-dont-need-lodash-underscore": youDontNeedLodashUnderscore },
+    "extends": [ "you-dont-need-lodash-underscore/flat/compatible" ],
+}
 ```
 
 The following options are available:

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict';
 const kebabCase = require('kebab-case');
 const rules = require('./lib/rules/rules.json')
-
-module.exports.rules = require('./lib/rules/all');
+const { name, version } = require('./package.json')
 
 const all = Object.keys(rules);
 const compatible = Object.keys(rules).filter(rule => rules[rule].compatible);
@@ -16,35 +15,54 @@ const configure = (list, level) => (
     { ['you-dont-need-lodash-underscore/' + (rules[rule].ruleName || kebabCase(rule))]: level })), {})
 )
 
-module.exports.configs = {
-  'all-warn': {
-    plugins: [
-      'you-dont-need-lodash-underscore'
-    ],
-    rules: configure(all, WARN)
-  },
+const plugin = {
+    meta: {
+        name,
+        version,
+    },
+    rules: require('./lib/rules/all'),
+    configs: {},
+    flatConfigs: {},
+};
 
-  'all': {
-    plugins: [
-      'you-dont-need-lodash-underscore'
-    ],
-    rules: configure(all, ERROR)
-  },
+Object.assign( plugin.flatConfigs, {
+    'all-warn': {
+        plugins: {
+            'you-dont-need-lodash-underscore': plugin,
+        },
+        rules: configure(all, WARN)
+    },
 
-  'compatible-warn': {
-    plugins: [
-      'you-dont-need-lodash-underscore'
-    ],
-    rules: configure(compatible, WARN)
-  },
+    'all': {
+        plugins: {
+            'you-dont-need-lodash-underscore': plugin,
+        },
+        rules: configure(all, ERROR)
+    },
 
-  'compatible': {
-    plugins: [
-      'you-dont-need-lodash-underscore'
-    ],
-    rules: Object.assign(
-      configure(compatible, ERROR),
-      configure(incompatible, WARN)
-    )
-  }
+    'compatible-warn': {
+        plugins: {
+            'you-dont-need-lodash-underscore': plugin,
+        },
+        rules: configure(compatible, WARN)
+    },
+
+    'compatible': {
+        plugins: {
+            'you-dont-need-lodash-underscore': plugin,
+        },
+        rules: Object.assign(
+            configure(compatible, ERROR),
+            configure(incompatible, WARN)
+        )
+    }
+} );
+
+for ( const [ key, config ] of Object.entries( plugin.flatConfigs ) ) {
+    plugin.configs[ key ] = Object.assign( {}, config, {
+        plugins: [ 'you-dont-need-lodash-underscore' ],
+    } );
+    plugin.configs[ 'flat/' + key ] = config;
 }
+
+module.exports = plugin;

--- a/tests/index.js
+++ b/tests/index.js
@@ -11,3 +11,22 @@ assert.equal(plugin.configs['compatible-warn'].rules['you-dont-need-lodash-under
 assert.equal(plugin.configs['compatible-warn'].rules['you-dont-need-lodash-underscore/last-index-of'], 1);
 assert.equal(plugin.configs.compatible.rules['you-dont-need-lodash-underscore/for-each'], 1);
 assert.equal(plugin.configs.compatible.rules['you-dont-need-lodash-underscore/is-nan'], 2);
+
+assert.equal(plugin.flatConfigs['all-warn'].rules['you-dont-need-lodash-underscore/contains'], 1);
+assert.equal(plugin.flatConfigs['all-warn'].rules['you-dont-need-lodash-underscore/trim'], 1);
+assert.equal(plugin.flatConfigs.all.rules['you-dont-need-lodash-underscore/every'], 2);
+assert.equal(plugin.flatConfigs.all.rules['you-dont-need-lodash-underscore/keys'], 2);
+assert.equal(plugin.flatConfigs['compatible-warn'].rules['you-dont-need-lodash-underscore/each'], undefined);
+assert.equal(plugin.flatConfigs['compatible-warn'].rules['you-dont-need-lodash-underscore/last-index-of'], 1);
+assert.equal(plugin.flatConfigs.compatible.rules['you-dont-need-lodash-underscore/for-each'], 1);
+assert.equal(plugin.flatConfigs.compatible.rules['you-dont-need-lodash-underscore/is-nan'], 2);
+
+assert.strictEqual(plugin.flatConfigs['all-warn'].plugins['you-dont-need-lodash-underscore'], plugin);
+assert.strictEqual(plugin.flatConfigs.all.plugins['you-dont-need-lodash-underscore'], plugin);
+assert.strictEqual(plugin.flatConfigs['compatible-warn'].plugins['you-dont-need-lodash-underscore'], plugin);
+assert.strictEqual(plugin.flatConfigs.compatible.plugins['you-dont-need-lodash-underscore'], plugin);
+
+assert.strictEqual(plugin.configs['flat/all-warn'], plugin.flatConfigs['all-warn']);
+assert.strictEqual(plugin.configs['flat/all'], plugin.flatConfigs.all);
+assert.strictEqual(plugin.configs['flat/compatible-warn'], plugin.flatConfigs['compatible-warn']);
+assert.strictEqual(plugin.configs['flat/compatible'], plugin.flatConfigs.compatible);


### PR DESCRIPTION
ESLint doesn't define any specific method for providing flat configs alongside legacy configs without it being a breaking change (with a breaking change, they'd recommend names like "all-legacy"). This PR implements two methods:

1. `.flatConfigs.compatible`
2. `.configs[ 'flat/compatible' ]`

The first is more convenient for direct use, while the second will work with the string version of `extends` supported by `defineConfig()`.

Fixes #396